### PR TITLE
fix: align workflow job names with branch ruleset check contexts

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   actionlint:
-    name: Lint workflow files
+    name: actionlint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-datasets.yml
+++ b/.github/workflows/validate-datasets.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate:
-    name: Validate CSV Datasets
+    name: Validate Datasets
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- Renames `actionlint` job display name from `Lint workflow files` → `actionlint`
- Renames `validate` job display name from `Validate CSV Datasets` → `Validate Datasets`

The `main-protection` ruleset requires status check contexts named exactly `actionlint` and `Validate Datasets`. The jobs were producing contexts `Lint workflow files` and `Validate CSV Datasets`, so the required checks were never satisfied and all PRs were stuck as BLOCKED.

Once this merges, the 4 open Dependabot PRs can be rebased and merged cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)