### PR TITLE
docs: add Arabic GitHub beginner guide link for legal contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,17 @@ Legislative sources do not replace judicial decisions, and vice versa.
 
 ---
 
+### 🆕 جديد على GitHub؟ ابدأ من هنا
+
+إذا كنت محاميا او مستشارا قانونيا ولا تعرف GitHub، لا تقلق.
+اعددنا دليلا عربيا شاملا يشرح كل شيء خطوة بخطوة:
+
+👉 [دليل GitHub للمبتدئين بالعربي](https://samix2026.github.io/github-beginner-guide-ar/)
+
+بعد قراءة الدليل، عد هنا وابدأ مساهمتك.
+
+---
+
 ## Contribution Workflow
 
 ```

--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ Long-term (v3.0): a web interface for legal professionals and organizations to u
 
 راجع [CONTRIBUTING.md](CONTRIBUTING.md) للدليل الكامل بما يشمل معايير مجموعات البيانات وصيغ الاستشهاد ومتطلبات اخفاء الهوية وقائمة التحقق قبل التقديم.
 
+> جديد على GitHub؟ اقرأ [الدليل العربي للمبتدئين](https://samix2026.github.io/github-beginner-guide-ar/) اولا.
+
 اقرأ [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) قبل المساهمة. للابلاغ عن مشكلة امنية (مثل بيانات غير معماة)، راجع [SECURITY.md](SECURITY.md).
 
 ### مسارات المساهمة


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md** — adds `### 🆕 جديد على GitHub؟ ابدأ من هنا` subsection immediately before `## Contribution Workflow`, with a link to the Arabic beginner guide for legal professionals unfamiliar with GitHub
- **README.md** — adds a single blockquote line under `## دليل المساهمة / Contribution Guide` pointing to the same guide

## Changes

Purely additive documentation change. No code, no datasets, no legal content modified.

## Test plan

- [ ] Confirm new subsection appears before `## Contribution Workflow` in CONTRIBUTING.md
- [ ] Confirm blockquote line appears under `## دليل المساهمة` in README.md
- [ ] Verify no tashkeel in added Arabic text
- [ ] Validate Datasets CI passes (no CSV files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)