### PR TITLE
feat: typed bidirectional skill relationship graph

### DIFF
--- a/.github/workflows/validate-datasets.yml
+++ b/.github/workflows/validate-datasets.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Validate cross-references
         run: python3 scripts/validate_cross_refs.py
 
+      - name: Validate example coverage
+        run: python3 scripts/validate_example_coverage.py
+
       - name: Validate main dataset
         run: python3 scripts/validate_dataset.py
 

--- a/.github/workflows/validate-datasets.yml
+++ b/.github/workflows/validate-datasets.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run tests
         run: pytest
 
+      - name: Validate cross-references
+        run: python scripts/validate_cross_refs.py
+
       - name: Validate main dataset
         run: python3 scripts/validate_dataset.py
 

--- a/.github/workflows/validate-datasets.yml
+++ b/.github/workflows/validate-datasets.yml
@@ -25,7 +25,7 @@ jobs:
         run: pytest
 
       - name: Validate cross-references
-        run: python scripts/validate_cross_refs.py
+        run: python3 scripts/validate_cross_refs.py
 
       - name: Validate main dataset
         run: python3 scripts/validate_dataset.py

--- a/.github/workflows/validate-datasets.yml
+++ b/.github/workflows/validate-datasets.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Validate example coverage
         run: python3 scripts/validate_example_coverage.py
 
+      - name: Validate skill graph
+        run: python3 scripts/validate_skill_graph.py
+
       - name: Validate main dataset
         run: python3 scripts/validate_dataset.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ desktop.ini
 datasets/build/*.generated.csv
 experiments/ocr-scan/
 
+# Python
+__pycache__/
+*.pyc
+*.pyo
+
 # Claude Code / agents
 .agents/
 .claude/

--- a/docs/cross-reference-map.md
+++ b/docs/cross-reference-map.md
@@ -37,6 +37,36 @@ This map shows the relationships between project files. The goal: every contribu
 
 ---
 
+## 1b. Sources → Skills — Reverse Index / المصادر → المهارات (فهرس عكسي)
+
+> هذا الجدول مصدر الحقيقة للـ CI — يُشغِّل `scripts/validate_cross_refs.py` في كل push.
+> أي تغيير في §11 لأي skill يستلزم تحديث هذا الجدول.
+> This table is the CI source of truth. Any change to a skill's §11 requires updating it.
+
+| Source File | Cited by Skill | Section | طبيعة الاستخدام |
+|---|---|---|---|
+| `sources/civil-transactions-law.md` | `skills/labor-law-analysis.md` | §11 | مبادئ العقود التكميلية |
+| `sources/civil-transactions-law.md` | `skills/commercial-dispute.md` | §11 | العقود والالتزامات — أساس المطالبات |
+| `sources/civil-transactions-law.md` | `skills/compliance-check.md` | §11 | التزامات تعاقدية تنظيمية |
+| `sources/civil-transactions-law.md` | `skills/legal-drafting.md` | §11 | الإطار العام للعقود والالتزامات |
+| `sources/civil-transactions-law.md` | `skills/arbitration.md` | §11 | مبادئ العقود والالتزامات في النزاعات |
+| `sources/civil-transactions-law.md` | `skills/real-estate-contracts.md` | §11 | مبادئ العقود والالتزامات العامة |
+| `sources/labor-law.md` | `skills/labor-law-analysis.md` | §11 | الإطار الحاكم الأساسي |
+| `sources/labor-law.md` | `skills/compliance-check.md` | §11 | السعودة، WPS، GOSI |
+| `sources/labor-law.md` | `skills/legal-drafting.md` | §11 | عقود العمل — أحكام آمرة |
+| `sources/companies-law.md` | `skills/commercial-dispute.md` | §11 | نزاعات المساهمين والشركاء |
+| `sources/companies-law.md` | `skills/compliance-check.md` | §11 | هيكل الملكية ومتطلبات الإفصاح |
+| `sources/companies-law.md` | `skills/legal-drafting.md` | §11 | وثائق الشركات والمساهمين |
+| `sources/companies-law.md` | `skills/real-estate-contracts.md` | §11 | عقارات الشركات والتصرف فيها |
+| `sources/pdpl.md` | `skills/labor-law-analysis.md` | §11 | بنود السرية في عقود العمل |
+| `sources/pdpl.md` | `skills/compliance-check.md` | §11 | PDPL — نقل البيانات والخصوصية |
+| `sources/pdpl.md` | `skills/legal-drafting.md` | §11 | بنود السرية ومعالجة البيانات |
+| `sources/commercial-courts.md` | `skills/commercial-dispute.md` | §11 | الإطار الإجرائي الأساسي |
+| `sources/commercial-courts.md` | `skills/compliance-check.md` | §11 | فض النزاعات التنظيمية |
+| `sources/commercial-courts.md` | `skills/arbitration.md` | §11 | الرقابة القضائية على التحكيم وتنفيذ الاحكام |
+
+---
+
 ## 2. Skills ← → Prompts / المهارات ← → قوالب المطالبات
 
 | Skill | Related Prompts | طبيعة العلاقة |
@@ -251,6 +281,17 @@ Every change to a core file requires updating this map and the files linked to i
 
 ---
 
+### عند تعديل §11 في Skill / When Editing a Skill's §11
+
+```
+✅ حدّث Section 1b في:           docs/cross-reference-map.md
+✅ حدّث "See also" في:           كل sources/ file أُضيف أو حُذف من §11
+✅ شغّل محليًا:                  python scripts/validate_cross_refs.py
+✅ تأكد من خروج 0 قبل الـ commit
+```
+
+---
+
 ### عند إضافة Enum جديد / When Adding a New Enum Value
 
 ```
@@ -337,6 +378,6 @@ sources/fiqh-judicial-references/  ≠  sources/regulation-index.md
 
 ---
 
-*آخر تحديث / Last updated: 2026-05-17 — يعكس حالة المشروع في v0.3 (fiqh reference layer + judicial extractions batch 1)*
+*آخر تحديث / Last updated: 2026-05-25 — إضافة Section 1b (reverse index) + validate_cross_refs.py*
 
 *حدّث هذا التاريخ عند كل مراجعة للخريطة. / Update this date on every map revision.*

--- a/docs/cross-reference-map.md
+++ b/docs/cross-reference-map.md
@@ -83,11 +83,34 @@ This map shows the relationships between project files. The goal: every contribu
 
 | Skill | Related Examples | ملاحظة |
 |---|---|---|
-| `skills/contract-review.md` | `examples/employment-contract-review.md` · `examples/nda-review.md` · `examples/saudi-contract-review-demo.md` | الـ demo هو التطبيق الكامل لـ §8 |
-| `skills/labor-law-analysis.md` | `examples/employment-contract-review.md` | المثال يُطبِّق تحليل نظام العمل |
-| `skills/commercial-dispute.md` | — | لا يوجد مثال تطبيقي بعد |
-| `skills/compliance-check.md` | — | لا يوجد مثال تطبيقي بعد |
-| `skills/legal-drafting.md` | — | لا يوجد مثال تطبيقي بعد |
+| `skills/arbitration.md` | `examples/arbitration-example.md` | نزاع توريد عابر للحدود |
+| `skills/commercial-dispute.md` | `examples/commercial-dispute-example.md` | تحليل نزاع تجاري |
+| `skills/compliance-check.md` | `examples/compliance-example.md` · `examples/pdpl-data-breach-example.md` | فحص امتثال SaaS + اختراق بيانات طبية |
+| `skills/contract-review.md` | `examples/contract-review-example.md` · `examples/employment-contract-review.md` · `examples/nda-review.md` · `examples/saudi-contract-review-demo.md` | الـ demo هو التطبيق الكامل لـ §8 |
+| `skills/labor-law-analysis.md` | `examples/employment-contract-review.md` · `examples/labor-dispute-job-change-example.md` · `examples/labor-law-example.md` | يتضمن حساب EOSB ونزاع تغيير المسمى |
+| `skills/legal-drafting.md` | `examples/legal-drafting-example.md` | صياغة عقد خدمات برمجيات |
+| `skills/real-estate-contracts.md` | `examples/commercial-lease-exit-example.md` · `examples/real-estate-example.md` | إيجار تجاري + سكني |
+
+---
+
+## Skill → Example Coverage
+
+> هذا الجدول مُولَّد من `## Related examples` في كل ملف `skills/*.md`.
+> يُشغَّل `scripts/validate_example_coverage.py` في كل push للتحقق منه.
+> This table is derived from `## Related examples` in each `skills/*.md` file.
+> `scripts/validate_example_coverage.py` runs on every push to verify it.
+
+| Skill | Example Count | Example Files | Coverage Status |
+|---|---|---|---|
+| `skills/arbitration.md` | 1 | `examples/arbitration-example.md` | Partial |
+| `skills/commercial-dispute.md` | 1 | `examples/commercial-dispute-example.md` | Partial |
+| `skills/compliance-check.md` | 2 | `examples/compliance-example.md` · `examples/pdpl-data-breach-example.md` | Strong |
+| `skills/contract-review.md` | 4 | `examples/contract-review-example.md` · `examples/employment-contract-review.md` · `examples/nda-review.md` · `examples/saudi-contract-review-demo.md` | Strong |
+| `skills/labor-law-analysis.md` | 3 | `examples/employment-contract-review.md` · `examples/labor-dispute-job-change-example.md` · `examples/labor-law-example.md` · | Strong |
+| `skills/legal-drafting.md` | 1 | `examples/legal-drafting-example.md` | Partial |
+| `skills/real-estate-contracts.md` | 2 | `examples/commercial-lease-exit-example.md` · `examples/real-estate-example.md` | Strong |
+
+**Coverage rules:** 0 examples → Missing | 1 example → Partial | 2+ examples → Strong
 
 ---
 
@@ -378,6 +401,6 @@ sources/fiqh-judicial-references/  ≠  sources/regulation-index.md
 
 ---
 
-*آخر تحديث / Last updated: 2026-05-25 — إضافة Section 1b (reverse index) + validate_cross_refs.py*
+*آخر تحديث / Last updated: 2026-05-25 — إضافة § Skill → Example Coverage + تحديث §3 + validate_example_coverage.py*
 
 *حدّث هذا التاريخ عند كل مراجعة للخريطة. / Update this date on every map revision.*

--- a/docs/cross-reference-map.md
+++ b/docs/cross-reference-map.md
@@ -114,6 +114,27 @@ This map shows the relationships between project files. The goal: every contribu
 
 ---
 
+## Skill Relationship Graph
+
+> هذا الجدول مُولَّد من `## Related skills` في كل ملف `skills/*.md`.
+> يُشغَّل `scripts/validate_skill_graph.py` في كل push للتحقق منه.
+> This table is derived from `## Related skills` in each `skills/*.md` file.
+> `scripts/validate_skill_graph.py` runs on every push to verify it.
+
+| Skill | Related Skills | Relationship Types | Graph Degree | Connectivity Status |
+|---|---|---|---|---|
+| `skills/arbitration.md` | `skills/commercial-dispute.md` · `skills/legal-drafting.md` | `alternative_to` · `depends_on` | 4 (2 out, 2 in) | Connected |
+| `skills/commercial-dispute.md` | `skills/arbitration.md` · `skills/legal-drafting.md` | `alternative_to` · `precedes` | 4 (2 out, 2 in) | Connected |
+| `skills/compliance-check.md` | `skills/labor-law-analysis.md` · `skills/contract-review.md` | `cross_checks` | 5 (2 out, 3 in) | Connected |
+| `skills/contract-review.md` | `skills/commercial-dispute.md` · `skills/arbitration.md` · `skills/legal-drafting.md` · `skills/compliance-check.md` | `escalates_to` · `precedes` · `cross_checks` | 8 (4 out, 4 in) | Connected |
+| `skills/labor-law-analysis.md` | `skills/compliance-check.md` · `skills/contract-review.md` | `cross_checks` · `depends_on` | 3 (2 out, 1 in) | Connected |
+| `skills/legal-drafting.md` | `skills/contract-review.md` | `depends_on` | 4 (1 out, 3 in) | Connected |
+| `skills/real-estate-contracts.md` | `skills/contract-review.md` · `skills/compliance-check.md` | `specializes` · `depends_on` | 2 (2 out, 0 in) | Connected |
+
+**Allowed relationship types:** `escalates_to` · `alternative_to` · `cross_checks` · `depends_on` · `specializes` · `precedes` · `shares_sources_with` · `overlaps_with`
+
+---
+
 ## 4. Sources ← → Regulations / المصادر ← → الأنظمة
 
 | Source File | Regulation | Royal Decree | صيغة الاستشهاد الرسمية |

--- a/docs/superpowers/plans/2026-05-25-reverse-discovery-seam.md
+++ b/docs/superpowers/plans/2026-05-25-reverse-discovery-seam.md
@@ -1,0 +1,1015 @@
+# Reverse-Discovery Seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a validated reverse-discovery seam so every `sources/` file cited by a skill links back to the skills that use it, enforced by CI.
+
+**Architecture:** A new CI script (`validate_cross_refs.py`) parses each skill's regulations section using alias-based heading detection, then checks that every cited source file has a `## See also` section listing the citing skills. `docs/cross-reference-map.md` gains a Section 1b reverse-index table as the authoritative CI source of truth.
+
+**Tech Stack:** Python 3.11 stdlib only (pathlib, re, sys, argparse) · pytest · GitHub Actions
+
+---
+
+## Pre-work: citation ground truth
+
+Before Task 3, the validator output (Task 2 step 5) reveals the actual citations. The table below is the verified ground truth from auditing all seven skills directly — use it to write the "See also" sections in Tasks 3–7.
+
+| Source file | Cited by skill | Description from §11 |
+|---|---|---|
+| `sources/civil-transactions-law.md` | `skills/labor-law-analysis.md` | مبادئ العقود التكميلية |
+| `sources/civil-transactions-law.md` | `skills/commercial-dispute.md` | العقود والالتزامات — أساس المطالبات |
+| `sources/civil-transactions-law.md` | `skills/compliance-check.md` | التزامات تعاقدية تنظيمية |
+| `sources/civil-transactions-law.md` | `skills/legal-drafting.md` | الإطار العام للعقود والالتزامات |
+| `sources/civil-transactions-law.md` | `skills/arbitration.md` | مبادئ العقود والالتزامات في النزاعات |
+| `sources/civil-transactions-law.md` | `skills/real-estate-contracts.md` | مبادئ العقود والالتزامات العامة |
+| `sources/labor-law.md` | `skills/labor-law-analysis.md` | الإطار الحاكم الأساسي |
+| `sources/labor-law.md` | `skills/compliance-check.md` | السعودة، WPS، GOSI |
+| `sources/labor-law.md` | `skills/legal-drafting.md` | عقود العمل — أحكام آمرة |
+| `sources/companies-law.md` | `skills/commercial-dispute.md` | نزاعات المساهمين والشركاء |
+| `sources/companies-law.md` | `skills/compliance-check.md` | هيكل الملكية ومتطلبات الإفصاح |
+| `sources/companies-law.md` | `skills/legal-drafting.md` | وثائق الشركات والمساهمين |
+| `sources/companies-law.md` | `skills/real-estate-contracts.md` | عقارات الشركات والتصرف فيها |
+| `sources/pdpl.md` | `skills/labor-law-analysis.md` | بنود السرية في عقود العمل |
+| `sources/pdpl.md` | `skills/compliance-check.md` | PDPL — نقل البيانات والخصوصية |
+| `sources/pdpl.md` | `skills/legal-drafting.md` | بنود السرية ومعالجة البيانات |
+| `sources/commercial-courts.md` | `skills/commercial-dispute.md` | الإطار الإجرائي الأساسي |
+| `sources/commercial-courts.md` | `skills/compliance-check.md` | فض النزاعات التنظيمية |
+| `sources/commercial-courts.md` | `skills/arbitration.md` | الرقابة القضائية على التحكيم وتنفيذ الاحكام |
+
+**Not cited (no See also needed):** `sources/saudi-laws.md` — no skill's §11 references it by path.
+
+**Excluded from validation:** `sources/regulation-index.md` — cited only as a citation-format reference (`EXCLUDED_SOURCES` constant in the script), not as a substantive legal source.
+
+**Note on `skills/contract-review.md`:** Its §11 does not use backtick-quoted `sources/` paths — it lists regulation names only. The validator will not detect any citations from it. This is a documentation gap to address in a follow-on task (not in scope here).
+
+---
+
+## File map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Create | `scripts/validate_cross_refs.py` | Parse skills + sources, run 4 checks, exit 1 on errors |
+| Create | `tests/test_validate_cross_refs.py` | Unit + integration tests for all parsing functions and checks |
+| Modify | `sources/civil-transactions-law.md` | Add `## See also` (6 skills) |
+| Modify | `sources/labor-law.md` | Add `## See also` (3 skills) |
+| Modify | `sources/companies-law.md` | Add `## See also` (4 skills) |
+| Modify | `sources/pdpl.md` | Add `## See also` (3 skills) |
+| Modify | `sources/commercial-courts.md` | Add `## See also` (3 skills) |
+| Modify | `docs/cross-reference-map.md` | Add Section 1b reverse-index table + two maintenance rules |
+| Modify | `.github/workflows/validate-datasets.yml` | Add `validate_cross_refs.py` step after pytest |
+
+---
+
+## Task 1: Write the failing tests
+
+**Files:**
+- Create: `tests/test_validate_cross_refs.py`
+
+- [ ] **Step 1: Create the test file**
+
+```python
+# tests/test_validate_cross_refs.py
+"""
+Tests for scripts/validate_cross_refs.py
+Saudi Legal AI Framework — reverse-discovery seam validator
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import validate_cross_refs as vcr
+
+
+# ── Heading detection ──────────────────────────────────────────────────────────
+
+def test_normalize_heading_strips_hashes():
+    assert vcr._normalize_heading("## Introduction") == "introduction"
+
+def test_normalize_heading_strips_section_number():
+    assert vcr._normalize_heading("## 11. Relevant Regulations / الأنظمة ذات الصلة") == "relevant regulations / الأنظمة ذات الصلة"
+
+def test_normalize_heading_strips_section_number_with_symbol():
+    assert vcr._normalize_heading("## §11 Relevant Regulations") == "relevant regulations"
+
+def test_is_regulations_heading_english():
+    assert vcr._is_regulations_heading("## 11. Relevant Regulations / الأنظمة ذات الصلة")
+
+def test_is_regulations_heading_arabic():
+    assert vcr._is_regulations_heading("## الأنظمة المرتبطة")
+
+def test_is_regulations_heading_unrelated():
+    assert not vcr._is_regulations_heading("## Introduction")
+
+def test_is_regulations_heading_case_insensitive():
+    assert vcr._is_regulations_heading("## RELEVANT REGULATIONS")
+
+def test_is_see_also_heading():
+    assert vcr._is_see_also_heading("## See also / انظر أيضًا")
+
+def test_is_see_also_heading_plain():
+    assert vcr._is_see_also_heading("## See also")
+
+def test_is_see_also_heading_unrelated():
+    assert not vcr._is_see_also_heading("## Overview")
+
+
+# ── Path extraction ────────────────────────────────────────────────────────────
+
+def test_extract_source_paths_backtick():
+    text = "See `sources/labor-law.md` for details"
+    assert vcr._extract_source_paths(text) == {"sources/labor-law.md"}
+
+def test_extract_source_paths_bare():
+    text = "See sources/pdpl.md in this project"
+    assert vcr._extract_source_paths(text) == {"sources/pdpl.md"}
+
+def test_extract_source_paths_multiple():
+    text = "`sources/labor-law.md` and `sources/pdpl.md`"
+    assert vcr._extract_source_paths(text) == {"sources/labor-law.md", "sources/pdpl.md"}
+
+def test_extract_source_paths_deduplicates():
+    text = "`sources/labor-law.md` appears twice `sources/labor-law.md`"
+    assert vcr._extract_source_paths(text) == {"sources/labor-law.md"}
+
+def test_extract_source_paths_excludes_regulation_index():
+    text = "راجع `sources/regulation-index.md` للصيغ الرسمية"
+    # regulation-index.md is in EXCLUDED_SOURCES — should not appear
+    assert "sources/regulation-index.md" not in vcr._extract_source_paths(text)
+
+def test_extract_skill_paths_backtick():
+    text = "Implemented in `skills/contract-review.md`"
+    assert vcr._extract_skill_paths(text) == {"skills/contract-review.md"}
+
+def test_extract_skill_paths_markdown_link():
+    text = "- [skills/contract-review.md](../skills/contract-review.md) — §11"
+    assert vcr._extract_skill_paths(text) == {"skills/contract-review.md"}
+
+
+# ── Section extraction ─────────────────────────────────────────────────────────
+
+def test_extract_section_returns_body(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Introduction\nSome text.\n\n"
+        "## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        "`sources/labor-law.md`\n\n"
+        "## 12. Next Section\nOther content.\n",
+        encoding="utf-8",
+    )
+    body = vcr._extract_section(skill.read_text(encoding="utf-8").splitlines(), vcr._is_regulations_heading)
+    assert "sources/labor-law.md" in body
+    assert "Next Section" not in body
+
+def test_extract_section_not_found_returns_empty(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text("## Introduction\nSome text.\n", encoding="utf-8")
+    body = vcr._extract_section(skill.read_text(encoding="utf-8").splitlines(), vcr._is_regulations_heading)
+    assert body == ""
+
+
+# ── parse_skill ────────────────────────────────────────────────────────────────
+
+def test_parse_skill_finds_sources_in_regulations_section(tmp_path):
+    skill = tmp_path / "labor-law-analysis.md"
+    skill.write_text(
+        "## Introduction\nSome intro.\n\n"
+        "## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        "| نظام العمل | م/51 | الإطار | `sources/labor-law.md` |\n"
+        "| PDPL | م/19 | السرية | `sources/pdpl.md` |\n"
+        "راجع `sources/regulation-index.md` للصيغ الرسمية.\n\n"
+        "## 12. Next\nOther.\n",
+        encoding="utf-8",
+    )
+    result = vcr.parse_skill(skill)
+    assert result == {"sources/labor-law.md", "sources/pdpl.md"}
+    assert "sources/regulation-index.md" not in result
+
+def test_parse_skill_ignores_sources_outside_regulations(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Introduction\nSee `sources/other.md` here.\n\n"
+        "## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        "`sources/labor-law.md`\n\n"
+        "## 12. Next\n",
+        encoding="utf-8",
+    )
+    assert vcr.parse_skill(skill) == {"sources/labor-law.md"}
+
+def test_parse_skill_arabic_heading(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## الأنظمة المرتبطة\n`sources/civil-transactions-law.md`\n\n## Next\n",
+        encoding="utf-8",
+    )
+    assert vcr.parse_skill(skill) == {"sources/civil-transactions-law.md"}
+
+def test_parse_skill_no_regulations_section_returns_empty(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text("## Introduction\nNo regulations here.\n", encoding="utf-8")
+    assert vcr.parse_skill(skill) == set()
+
+
+# ── parse_source ───────────────────────────────────────────────────────────────
+
+def test_parse_source_no_see_also(tmp_path):
+    source = tmp_path / "labor-law.md"
+    source.write_text("## Overview\nSome content.\n", encoding="utf-8")
+    has_see_also, skills = vcr.parse_source(source)
+    assert not has_see_also
+    assert skills == set()
+
+def test_parse_source_with_see_also_backtick(tmp_path):
+    source = tmp_path / "labor-law.md"
+    source.write_text(
+        "## Overview\nContent.\n\n"
+        "## See also / انظر أيضًا\n"
+        "- `skills/labor-law-analysis.md` — §11\n"
+        "- `skills/compliance-check.md` — §11\n",
+        encoding="utf-8",
+    )
+    has_see_also, skills = vcr.parse_source(source)
+    assert has_see_also
+    assert skills == {"skills/labor-law-analysis.md", "skills/compliance-check.md"}
+
+def test_parse_source_with_see_also_markdown_link(tmp_path):
+    source = tmp_path / "labor-law.md"
+    source.write_text(
+        "## See also / انظر أيضًا\n"
+        "| [skills/contract-review.md](../skills/contract-review.md) | §11 |\n",
+        encoding="utf-8",
+    )
+    has_see_also, skills = vcr.parse_source(source)
+    assert has_see_also
+    assert "skills/contract-review.md" in skills
+
+
+# ── run_checks integration ─────────────────────────────────────────────────────
+
+def _write_skill(path: Path, name: str, sources: list[str]) -> None:
+    rows = "\n".join(f"| reg | ref | desc | `{s}` |" for s in sources)
+    path.write_text(
+        f"## Introduction\nIntro.\n\n"
+        f"## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        f"{rows}\n"
+        f"راجع `sources/regulation-index.md` للصيغ الرسمية.\n\n"
+        f"## 12. Next\nOther.\n",
+        encoding="utf-8",
+    )
+
+def _write_source_with_see_also(path: Path, skills: list[str]) -> None:
+    rows = "\n".join(
+        f"| [skills/{s}](../skills/{s}) | §11 | desc |"
+        for s in skills
+    )
+    path.write_text(
+        f"## Overview\nContent.\n\n---\n\n"
+        f"## See also / انظر أيضًا\n\n"
+        f"| Skill | Section | طبيعة الاستخدام |\n"
+        f"|-------|---------|----------------|\n"
+        f"{rows}\n",
+        encoding="utf-8",
+    )
+
+def _write_source_no_see_also(path: Path) -> None:
+    path.write_text("## Overview\nContent.\n", encoding="utf-8")
+
+
+def test_run_checks_passes_when_all_correct(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+
+    _write_skill(skills_dir / "labor-law-analysis.md", "labor-law-analysis", ["sources/labor-law.md"])
+    _write_source_with_see_also(sources_dir / "labor-law.md", ["labor-law-analysis.md"])
+    cross_ref.write_text(
+        "## 1b.\n`sources/labor-law.md` | `skills/labor-law-analysis.md`\n",
+        encoding="utf-8",
+    )
+
+    errors, warnings = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert errors == []
+    assert warnings == []
+
+
+def test_run_checks_check1_missing_see_also(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+
+    _write_skill(skills_dir / "labor-law-analysis.md", "labor-law-analysis", ["sources/labor-law.md"])
+    _write_source_no_see_also(sources_dir / "labor-law.md")
+
+    errors, _ = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert any("no '## See also'" in e for e in errors)
+
+
+def test_run_checks_check2_missing_reverse_link(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+
+    _write_skill(skills_dir / "compliance-check.md", "compliance-check", ["sources/labor-law.md"])
+    # See also exists but is missing compliance-check.md
+    _write_source_with_see_also(sources_dir / "labor-law.md", ["labor-law-analysis.md"])
+
+    errors, _ = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert any("missing skills/compliance-check.md" in e for e in errors)
+
+
+def test_run_checks_check3_phantom_reference(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+
+    # skill does NOT cite sources/labor-law.md
+    _write_skill(skills_dir / "legal-drafting.md", "legal-drafting", ["sources/pdpl.md"])
+    (sources_dir / "pdpl.md").write_text("## Overview\n", encoding="utf-8")
+    # but labor-law.md See also lists legal-drafting.md — phantom
+    _write_source_with_see_also(sources_dir / "labor-law.md", ["legal-drafting.md"])
+
+    errors, _ = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert any("phantom" in e.lower() or "does not cite" in e for e in errors)
+
+
+def test_run_checks_check4_map_missing_row_is_warning(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text("# Map\nNo rows yet.\n", encoding="utf-8")  # empty map
+
+    _write_skill(skills_dir / "labor-law-analysis.md", "labor-law-analysis", ["sources/labor-law.md"])
+    _write_source_with_see_also(sources_dir / "labor-law.md", ["labor-law-analysis.md"])
+
+    errors, warnings = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert errors == []
+    assert any("cross-reference-map" in w for w in warnings)
+```
+
+- [ ] **Step 2: Run tests — confirm all fail with ImportError**
+
+```bash
+cd /Users/samialmohaimeed/saudi-legal-ai-framework
+pytest tests/test_validate_cross_refs.py -v 2>&1 | head -20
+```
+
+Expected output: `ModuleNotFoundError: No module named 'validate_cross_refs'`
+
+---
+
+## Task 2: Implement `validate_cross_refs.py`
+
+**Files:**
+- Create: `scripts/validate_cross_refs.py`
+
+- [ ] **Step 1: Create the script**
+
+```python
+#!/usr/bin/env python3
+"""
+validate_cross_refs.py
+Saudi Legal AI Framework — reverse-discovery seam validator
+
+Checks that every sources/ file cited in a skill's regulations section
+has a matching ## See also section listing that skill.
+
+Usage:
+    python scripts/validate_cross_refs.py          # validate
+    python scripts/validate_cross_refs.py --fix    # auto-fix (not yet implemented)
+
+Exit codes: 0 = pass, 1 = errors found
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+SOURCES_DIR = REPO_ROOT / "sources"
+CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"
+
+# Heading aliases for the regulations section — add future aliases here.
+# Matching is case-insensitive and strips leading #, digits, §, and whitespace.
+REGULATIONS_HEADING_ALIASES = [
+    "relevant regulations",
+    "الأنظمة المرتبطة",
+    "الأنظمة ذات الصلة",
+]
+
+# Heading aliases for the See also section.
+SEE_ALSO_HEADING_ALIASES = [
+    "see also",
+    "انظر أيضًا",
+]
+
+# Sources excluded from validation — meta-documents that are not substantive
+# legal sources (cited only as format/citation references).
+EXCLUDED_SOURCES = {
+    "sources/regulation-index.md",
+}
+
+
+def _normalize_heading(line: str) -> str:
+    """Strip leading #, section numbers (11., §11), and lowercase."""
+    text = re.sub(r"^#+\s*", "", line)
+    text = re.sub(r"^\d+\.\s*", "", text)
+    text = re.sub(r"§\d+\s*", "", text)
+    return text.strip().lower()
+
+
+def _is_regulations_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in REGULATIONS_HEADING_ALIASES)
+
+
+def _is_see_also_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in SEE_ALSO_HEADING_ALIASES)
+
+
+def _heading_level(line: str) -> int:
+    m = re.match(r"^(#+)", line)
+    return len(m.group(1)) if m else 0
+
+
+def _extract_section(lines: list[str], heading_predicate) -> str:
+    """Return the text body of the first section matching heading_predicate."""
+    in_section = False
+    section_level = 0
+    body: list[str] = []
+    for line in lines:
+        if not in_section:
+            if line.startswith("#") and heading_predicate(line):
+                in_section = True
+                section_level = _heading_level(line)
+        else:
+            lvl = _heading_level(line)
+            if line.startswith("#") and lvl <= section_level:
+                break
+            body.append(line)
+    return "\n".join(body)
+
+
+def _extract_source_paths(text: str) -> set[str]:
+    """Return all sources/*.md paths mentioned in text, excluding EXCLUDED_SOURCES."""
+    found = set(re.findall(r"sources/[\w-]+\.md", text))
+    return found - EXCLUDED_SOURCES
+
+
+def _extract_skill_paths(text: str) -> set[str]:
+    """Return all skills/*.md paths mentioned in text."""
+    return set(re.findall(r"skills/[\w-]+\.md", text))
+
+
+def parse_skill(path: Path) -> set[str]:
+    """Return sources/*.md paths cited in this skill's regulations section."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    section_text = _extract_section(lines, _is_regulations_heading)
+    return _extract_source_paths(section_text)
+
+
+def parse_source(path: Path) -> tuple[bool, set[str]]:
+    """Return (has_see_also, set of skills/*.md paths listed in See also)."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    section_text = _extract_section(lines, _is_see_also_heading)
+    has_see_also = bool(section_text.strip())
+    return has_see_also, _extract_skill_paths(section_text)
+
+
+def run_checks(
+    skills_dir: Path = SKILLS_DIR,
+    sources_dir: Path = SOURCES_DIR,
+    cross_ref_map: Path = CROSS_REF_MAP,
+) -> tuple[list[str], list[str]]:
+    """
+    Run all four checks. Returns (errors, warnings).
+    errors  → Check 1 / 2 / 3 (CI-blocking)
+    warnings → Check 4 (documentation drift, non-blocking)
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # Build (source_path → set of citing skill_paths) from all skills
+    skill_citations: dict[str, set[str]] = {}
+    for skill_file in sorted(skills_dir.glob("*.md")):
+        cited = parse_skill(skill_file)
+        skill_path = f"skills/{skill_file.name}"
+        for source_path in cited:
+            skill_citations.setdefault(source_path, set()).add(skill_path)
+
+    # Parse each cited source's See also
+    source_see_also: dict[str, set[str]] = {}
+    for source_path_str, citing_skills in skill_citations.items():
+        source_file = sources_dir / Path(source_path_str).name
+        if not source_file.exists():
+            errors.append(
+                f"ERROR: {source_path_str} is referenced in skills but file not found."
+            )
+            continue
+
+        has_see_also, listed_skills = parse_source(source_file)
+        source_see_also[source_path_str] = listed_skills
+
+        # Check 1: cited source has no See also section
+        if not has_see_also:
+            for skill in sorted(citing_skills):
+                errors.append(
+                    f"ERROR: {source_path_str} is cited by {skill} "
+                    f"(regulations section) but has no '## See also' section."
+                )
+            continue
+
+        # Check 2: See also is missing a citing skill
+        for skill in sorted(citing_skills):
+            if skill not in listed_skills:
+                errors.append(
+                    f"ERROR: {source_path_str} 'See also' is missing {skill} "
+                    f"(cited in its regulations section)."
+                )
+
+    # Check 3: phantom references (See also lists a skill that doesn't cite it)
+    for source_path_str, listed_skills in source_see_also.items():
+        citing_skills = skill_citations.get(source_path_str, set())
+        for skill in sorted(listed_skills):
+            if skill not in citing_skills:
+                errors.append(
+                    f"ERROR: {source_path_str} 'See also' lists {skill} "
+                    f"but {skill} regulations section does not cite {source_path_str}."
+                )
+
+    # Check 4: cross-reference-map.md Section 1b sync (warn only)
+    map_text = cross_ref_map.read_text(encoding="utf-8") if cross_ref_map.exists() else ""
+    for source_path_str, citing_skills in skill_citations.items():
+        for skill in sorted(citing_skills):
+            if source_path_str not in map_text or skill not in map_text:
+                warnings.append(
+                    f"WARNING: cross-reference-map.md Section 1b may be missing row: "
+                    f"{source_path_str} → {skill}"
+                )
+
+    return errors, warnings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate reverse-discovery seam in sources/ and skills/."
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix missing See also sections (not yet implemented).",
+    )
+    args = parser.parse_args()
+
+    if args.fix:
+        print("--fix mode is not yet implemented.")
+        sys.exit(0)
+
+    errors, warnings = run_checks()
+
+    for w in warnings:
+        print(w)
+    for e in errors:
+        print(e)
+
+    if not errors and not warnings:
+        print("✓ All cross-reference checks passed.")
+    elif not errors:
+        print("✓ No errors. See warnings above.")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Run tests — confirm they pass**
+
+```bash
+pytest tests/test_validate_cross_refs.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Run validator to see current errors (audit)**
+
+```bash
+python scripts/validate_cross_refs.py
+```
+
+Expected output (before any See also sections exist):
+
+```
+WARNING: cross-reference-map.md Section 1b may be missing row: ...
+ERROR: sources/civil-transactions-law.md is cited by skills/arbitration.md ... but has no '## See also' section.
+ERROR: sources/civil-transactions-law.md is cited by skills/commercial-dispute.md ... but has no '## See also' section.
+... (19 errors total, one per pair in the pre-work table)
+```
+
+Exit code: 1
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/validate_cross_refs.py tests/test_validate_cross_refs.py
+git commit -m "feat: add validate_cross_refs.py with full test suite"
+```
+
+---
+
+## Task 3: Add `## See also` to `sources/civil-transactions-law.md`
+
+**Files:**
+- Modify: `sources/civil-transactions-law.md`
+
+- [ ] **Step 1: Append the See also section**
+
+Add this block at the very end of `sources/civil-transactions-law.md` (after the last `<!-- TODO -->` comment):
+
+```markdown
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/labor-law-analysis.md](../skills/labor-law-analysis.md) | §11 الأنظمة ذات الصلة | مبادئ العقود التكميلية |
+| [skills/commercial-dispute.md](../skills/commercial-dispute.md) | §11 الأنظمة ذات الصلة | العقود والالتزامات — أساس المطالبات |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | التزامات تعاقدية تنظيمية |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة ذات الصلة | الإطار العام للعقود والالتزامات |
+| [skills/arbitration.md](../skills/arbitration.md) | §11 الأنظمة ذات الصلة | مبادئ العقود والالتزامات في النزاعات |
+| [skills/real-estate-contracts.md](../skills/real-estate-contracts.md) | §11 الأنظمة ذات الصلة | مبادئ العقود والالتزامات العامة |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)
+```
+
+- [ ] **Step 2: Run validator — civil-transactions errors should clear**
+
+```bash
+python scripts/validate_cross_refs.py 2>&1 | grep "civil-transactions"
+```
+
+Expected: no output (no errors for this file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sources/civil-transactions-law.md
+git commit -m "docs: add See also section to civil-transactions-law.md"
+```
+
+---
+
+## Task 4: Add `## See also` to `sources/labor-law.md`
+
+**Files:**
+- Modify: `sources/labor-law.md`
+
+- [ ] **Step 1: Append the See also section**
+
+Add at the very end of `sources/labor-law.md`:
+
+```markdown
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/labor-law-analysis.md](../skills/labor-law-analysis.md) | §11 الأنظمة ذات الصلة | الإطار الحاكم الأساسي |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | السعودة، WPS، GOSI |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة ذات الصلة | عقود العمل — أحكام آمرة |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)
+```
+
+- [ ] **Step 2: Run validator — labor-law errors should clear**
+
+```bash
+python scripts/validate_cross_refs.py 2>&1 | grep "labor-law"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sources/labor-law.md
+git commit -m "docs: add See also section to labor-law.md"
+```
+
+---
+
+## Task 5: Add `## See also` to `sources/companies-law.md`
+
+**Files:**
+- Modify: `sources/companies-law.md`
+
+- [ ] **Step 1: Append the See also section**
+
+Add at the very end of `sources/companies-law.md`:
+
+```markdown
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/commercial-dispute.md](../skills/commercial-dispute.md) | §11 الأنظمة ذات الصلة | نزاعات المساهمين والشركاء |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | هيكل الملكية ومتطلبات الإفصاح |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة ذات الصلة | وثائق الشركات والمساهمين |
+| [skills/real-estate-contracts.md](../skills/real-estate-contracts.md) | §11 الأنظمة ذات الصلة | عقارات الشركات والتصرف فيها |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)
+```
+
+- [ ] **Step 2: Run validator — companies-law errors should clear**
+
+```bash
+python scripts/validate_cross_refs.py 2>&1 | grep "companies-law"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sources/companies-law.md
+git commit -m "docs: add See also section to companies-law.md"
+```
+
+---
+
+## Task 6: Add `## See also` to `sources/pdpl.md`
+
+**Files:**
+- Modify: `sources/pdpl.md`
+
+- [ ] **Step 1: Append the See also section**
+
+Add at the very end of `sources/pdpl.md`:
+
+```markdown
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/labor-law-analysis.md](../skills/labor-law-analysis.md) | §11 الأنظمة ذات الصلة | بنود السرية في عقود العمل |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | PDPL — نقل البيانات والخصوصية |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة ذات الصلة | بنود السرية ومعالجة البيانات |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)
+```
+
+- [ ] **Step 2: Run validator — pdpl errors should clear**
+
+```bash
+python scripts/validate_cross_refs.py 2>&1 | grep "pdpl"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sources/pdpl.md
+git commit -m "docs: add See also section to pdpl.md"
+```
+
+---
+
+## Task 7: Add `## See also` to `sources/commercial-courts.md`
+
+**Files:**
+- Modify: `sources/commercial-courts.md`
+
+- [ ] **Step 1: Append the See also section**
+
+Add at the very end of `sources/commercial-courts.md`:
+
+```markdown
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/commercial-dispute.md](../skills/commercial-dispute.md) | §11 الأنظمة ذات الصلة | الإطار الإجرائي الأساسي |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | فض النزاعات التنظيمية |
+| [skills/arbitration.md](../skills/arbitration.md) | §11 الأنظمة ذات الصلة | الرقابة القضائية على التحكيم وتنفيذ الاحكام |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)
+```
+
+- [ ] **Step 2: Run validator — should show only Check 4 warnings now**
+
+```bash
+python scripts/validate_cross_refs.py
+```
+
+Expected: zero ERRORs, only WARNING lines about cross-reference-map.md Section 1b. Exit code: 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sources/commercial-courts.md
+git commit -m "docs: add See also section to commercial-courts.md"
+```
+
+---
+
+## Task 8: Add Section 1b to `docs/cross-reference-map.md`
+
+**Files:**
+- Modify: `docs/cross-reference-map.md`
+
+- [ ] **Step 1: Insert Section 1b after Section 1**
+
+In `docs/cross-reference-map.md`, find the line:
+
+```
+---
+
+## 2. Skills ← → Prompts / المهارات ← → قوالب المطالبات
+```
+
+Insert this block immediately before it:
+
+```markdown
+---
+
+## 1b. Sources → Skills — Reverse Index / المصادر → المهارات (فهرس عكسي)
+
+> هذا الجدول مصدر الحقيقة للـ CI — يُشغِّل `scripts/validate_cross_refs.py` في كل push.
+> أي تغيير في §11 لأي skill يستلزم تحديث هذا الجدول.
+> This table is the CI source of truth. Any change to a skill's §11 requires updating it.
+
+| Source File | Cited by Skill | Section | طبيعة الاستخدام |
+|---|---|---|---|
+| `sources/civil-transactions-law.md` | `skills/labor-law-analysis.md` | §11 | مبادئ العقود التكميلية |
+| `sources/civil-transactions-law.md` | `skills/commercial-dispute.md` | §11 | العقود والالتزامات — أساس المطالبات |
+| `sources/civil-transactions-law.md` | `skills/compliance-check.md` | §11 | التزامات تعاقدية تنظيمية |
+| `sources/civil-transactions-law.md` | `skills/legal-drafting.md` | §11 | الإطار العام للعقود والالتزامات |
+| `sources/civil-transactions-law.md` | `skills/arbitration.md` | §11 | مبادئ العقود والالتزامات في النزاعات |
+| `sources/civil-transactions-law.md` | `skills/real-estate-contracts.md` | §11 | مبادئ العقود والالتزامات العامة |
+| `sources/labor-law.md` | `skills/labor-law-analysis.md` | §11 | الإطار الحاكم الأساسي |
+| `sources/labor-law.md` | `skills/compliance-check.md` | §11 | السعودة، WPS، GOSI |
+| `sources/labor-law.md` | `skills/legal-drafting.md` | §11 | عقود العمل — أحكام آمرة |
+| `sources/companies-law.md` | `skills/commercial-dispute.md` | §11 | نزاعات المساهمين والشركاء |
+| `sources/companies-law.md` | `skills/compliance-check.md` | §11 | هيكل الملكية ومتطلبات الإفصاح |
+| `sources/companies-law.md` | `skills/legal-drafting.md` | §11 | وثائق الشركات والمساهمين |
+| `sources/companies-law.md` | `skills/real-estate-contracts.md` | §11 | عقارات الشركات والتصرف فيها |
+| `sources/pdpl.md` | `skills/labor-law-analysis.md` | §11 | بنود السرية في عقود العمل |
+| `sources/pdpl.md` | `skills/compliance-check.md` | §11 | PDPL — نقل البيانات والخصوصية |
+| `sources/pdpl.md` | `skills/legal-drafting.md` | §11 | بنود السرية ومعالجة البيانات |
+| `sources/commercial-courts.md` | `skills/commercial-dispute.md` | §11 | الإطار الإجرائي الأساسي |
+| `sources/commercial-courts.md` | `skills/compliance-check.md` | §11 | فض النزاعات التنظيمية |
+| `sources/commercial-courts.md` | `skills/arbitration.md` | §11 | الرقابة القضائية على التحكيم وتنفيذ الاحكام |
+
+```
+
+- [ ] **Step 2: Add "When editing a skill's §11" maintenance rule**
+
+In the maintenance rules section (after "When Adding a New Source"), add:
+
+```markdown
+### عند تعديل §11 في Skill / When Editing a Skill's §11
+
+```
+✅ حدّث Section 1b في:           docs/cross-reference-map.md
+✅ حدّث "See also" في:           كل sources/ file أُضيف أو حُذف من §11
+✅ شغّل محليًا:                  python scripts/validate_cross_refs.py
+✅ تأكد من خروج 0 قبل الـ commit
+```
+```
+
+- [ ] **Step 3: Update the last-updated timestamp** (bottom of the file)
+
+Change:
+```
+*آخر تحديث / Last updated: 2026-05-17 — يعكس حالة المشروع في v0.3 ...*
+```
+To:
+```
+*آخر تحديث / Last updated: 2026-05-25 — إضافة Section 1b (reverse index) + validate_cross_refs.py*
+```
+
+- [ ] **Step 4: Run validator — confirm zero errors and zero warnings**
+
+```bash
+python scripts/validate_cross_refs.py
+```
+
+Expected:
+```
+✓ All cross-reference checks passed.
+```
+
+Exit code: 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/cross-reference-map.md
+git commit -m "docs: add Section 1b reverse index to cross-reference-map.md"
+```
+
+---
+
+## Task 9: Wire into CI
+
+**Files:**
+- Modify: `.github/workflows/validate-datasets.yml`
+
+- [ ] **Step 1: Add the validation step**
+
+In `.github/workflows/validate-datasets.yml`, after the `Run tests` step (pytest), add:
+
+```yaml
+      - name: Validate cross-references
+        run: python scripts/validate_cross_refs.py
+```
+
+The full jobs section should read:
+
+```yaml
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest
+
+      - name: Validate cross-references
+        run: python scripts/validate_cross_refs.py
+
+      - name: Validate main dataset
+        run: python3 scripts/validate_dataset.py
+      # ... rest unchanged
+```
+
+- [ ] **Step 2: Run the full local test suite to confirm nothing breaks**
+
+```bash
+pytest && python scripts/validate_cross_refs.py
+```
+
+Expected: pytest passes, validator exits 0 with `✓ All cross-reference checks passed.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/validate-datasets.yml
+git commit -m "ci: add validate_cross_refs.py step to validation workflow"
+```
+
+---
+
+## Self-review notes
+
+- `contract-review.md §11` uses regulation names only (no `sources/` paths) — the validator will not detect its citations. This is a documentation gap flagged in the pre-work section; resolving it requires adding backtick-quoted source paths to that skill's §11 (out of scope here).
+- `sources/saudi-laws.md` has no citations from any skill's §11 by path — no See also needed, confirmed by validator output in Task 2 step 3.
+- `sources/regulation-index.md` is excluded via `EXCLUDED_SOURCES` — it appears as a citation format reference in every skill's regulations section but is not a substantive legal source.
+- Check 4 warnings (map sync) are non-blocking — they clear only in Task 8 when Section 1b is added.

--- a/docs/superpowers/plans/2026-05-25-skill-example-coverage.md
+++ b/docs/superpowers/plans/2026-05-25-skill-example-coverage.md
@@ -1,0 +1,1042 @@
+# Skill → Example Coverage System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bidirectional skill → example coverage system so contributors and AI agents can instantly discover which skills have worked examples, which have none, and which examples demonstrate each skill.
+
+**Architecture:** A new validator (`scripts/validate_example_coverage.py`) parses `## Related examples` sections in every `skills/*.md` file using alias-based heading detection, verifies referenced example files exist, and produces coverage counts. A new table in `docs/cross-reference-map.md` gives the human-readable overview. CI blocks on broken paths and malformed sections; missing coverage is a non-blocking warning.
+
+**Tech Stack:** Python 3.11, pytest, pathlib, re (stdlib only — no new dependencies)
+
+---
+
+## Architecture: Invariants
+
+Before touching code, lock in these rules. Violation = test failure or CI error.
+
+1. **Forward link:** Every `skills/*.md` MUST eventually have a `## Related examples` section (enforced as warning today, error in future).
+2. **Path integrity:** Every `examples/` path listed in a `## Related examples` section MUST exist on disk. This is CI-blocking from day one.
+3. **Format integrity:** Every bullet item in a `## Related examples` section MUST contain a markdown link whose href resolves to `examples/*.md`. A bullet with no link is CI-blocking.
+4. **Section heading aliases:** Detection is alias-based, case-insensitive, strips `#`, digits, and `§` — never hardcoded to a section number.
+5. **Coverage table:** `docs/cross-reference-map.md §Skill → Example Coverage` is the authoritative human-readable index but is NOT CI source-of-truth. Divergence → warning only.
+
+## Architecture: Coverage Heuristics
+
+- `count == 0` → **Missing** (WARNING — non-blocking)
+- `count == 1` → **Partial** (OK)
+- `count >= 2` → **Strong** (OK)
+
+## Architecture: Failure/Warning Rules
+
+| Check | Condition | Severity |
+|---|---|---|
+| 1 | Bullet item in Related examples has no `[text](examples/…)` link | **ERROR** — CI-blocking |
+| 2 | Referenced example path does not exist on disk | **ERROR** — CI-blocking |
+| 3 | Skill has no `## Related examples` heading | **WARNING** — non-blocking |
+| 4 | Skill has 0 valid examples listed | **WARNING** — non-blocking |
+| 5 | Coverage table in cross-reference-map.md missing a row | **WARNING** — non-blocking |
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| **Create** | `scripts/validate_example_coverage.py` | Core validator: heading detection, link extraction, malformation checks, `run_checks`, `main` |
+| **Create** | `tests/test_validate_example_coverage.py` | Unit + integration tests for the validator |
+| **Modify** | `skills/arbitration.md` | Append `## Related examples` section |
+| **Modify** | `skills/commercial-dispute.md` | Append `## Related examples` section |
+| **Modify** | `skills/compliance-check.md` | Append `## Related examples` section |
+| **Modify** | `skills/contract-review.md` | Append `## Related examples` section |
+| **Modify** | `skills/labor-law-analysis.md` | Append `## Related examples` section |
+| **Modify** | `skills/legal-drafting.md` | Append `## Related examples` section |
+| **Modify** | `skills/real-estate-contracts.md` | Append `## Related examples` section |
+| **Modify** | `docs/cross-reference-map.md` | Add `## Skill → Example Coverage` section; fix stale §3 entries |
+| **Modify** | `.github/workflows/validate-datasets.yml` | Add `validate_example_coverage.py` step after `validate_cross_refs.py` |
+
+## Confirmed Skill → Example Mappings
+
+Derived by grepping `skills/` references inside each `examples/*.md` file and cross-checking `docs/cross-reference-map.md §3`:
+
+| Skill | Examples | Coverage |
+|---|---|---|
+| `skills/arbitration.md` | `examples/arbitration-example.md` | Partial |
+| `skills/commercial-dispute.md` | `examples/commercial-dispute-example.md` | Partial |
+| `skills/compliance-check.md` | `examples/compliance-example.md` · `examples/pdpl-data-breach-example.md` | Strong |
+| `skills/contract-review.md` | `examples/contract-review-example.md` · `examples/employment-contract-review.md` · `examples/nda-review.md` · `examples/saudi-contract-review-demo.md` | Strong |
+| `skills/labor-law-analysis.md` | `examples/employment-contract-review.md` · `examples/labor-dispute-job-change-example.md` · `examples/labor-law-example.md` | Strong |
+| `skills/legal-drafting.md` | `examples/legal-drafting-example.md` | Partial |
+| `skills/real-estate-contracts.md` | `examples/commercial-lease-exit-example.md` · `examples/real-estate-example.md` | Strong |
+
+---
+
+## Task 1: Core Functions + Unit Tests (TDD — write tests first)
+
+**Files:**
+- Create: `scripts/validate_example_coverage.py`
+- Create: `tests/test_validate_example_coverage.py`
+
+- [ ] **Step 1.1: Write the failing unit tests**
+
+Create `tests/test_validate_example_coverage.py` with this exact content:
+
+```python
+# tests/test_validate_example_coverage.py
+"""
+Tests for scripts/validate_example_coverage.py
+Saudi Legal AI Framework — skill→example coverage validator
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import validate_example_coverage as vec
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _write_skill_with_examples(path: Path, example_refs: list) -> None:
+    items = "\n".join(
+        f"* [{ref}](../{ref}) — description"
+        for ref in example_refs
+    )
+    path.write_text(
+        f"## Introduction\nIntro.\n\n"
+        f"## 11. Relevant Regulations\n\n"
+        f"## Related examples / أمثلة مرتبطة\n\n"
+        f"{items}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_no_section(path: Path) -> None:
+    path.write_text(
+        "## Introduction\nIntro.\n\n## 11. Relevant Regulations\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_malformed_item(path: Path) -> None:
+    path.write_text(
+        "## Related examples / أمثلة مرتبطة\n\n"
+        "* some description without a link\n",
+        encoding="utf-8",
+    )
+
+
+def _write_example(path: Path) -> None:
+    path.write_text("# Example\nContent.\n", encoding="utf-8")
+
+
+# ── Heading detection ──────────────────────────────────────────────────────────
+
+def test_normalize_heading_strips_hashes():
+    assert vec._normalize_heading("## Related examples") == "related examples"
+
+def test_normalize_heading_arabic():
+    assert vec._normalize_heading("## أمثلة مرتبطة") == "أمثلة مرتبطة"
+
+def test_normalize_heading_strips_section_number():
+    assert vec._normalize_heading("## 15. Related examples") == "related examples"
+
+def test_is_related_examples_heading_bilingual():
+    assert vec._is_related_examples_heading("## Related examples / أمثلة مرتبطة")
+
+def test_is_related_examples_heading_arabic_only():
+    assert vec._is_related_examples_heading("## أمثلة مرتبطة")
+
+def test_is_related_examples_heading_case_insensitive():
+    assert vec._is_related_examples_heading("## RELATED EXAMPLES")
+
+def test_is_related_examples_heading_with_section_number():
+    assert vec._is_related_examples_heading("## 15. Related examples")
+
+def test_is_related_examples_heading_unrelated():
+    assert not vec._is_related_examples_heading("## Introduction")
+
+def test_is_related_examples_heading_unrelated_arabic():
+    assert not vec._is_related_examples_heading("## الأنظمة ذات الصلة")
+
+
+# ── Path extraction ────────────────────────────────────────────────────────────
+
+def test_extract_example_paths_relative():
+    text = "* [examples/foo.md](../examples/foo.md) — description"
+    assert vec._extract_example_paths(text) == ["examples/foo.md"]
+
+def test_extract_example_paths_without_dotdot():
+    text = "* [foo](examples/foo.md) — description"
+    assert vec._extract_example_paths(text) == ["examples/foo.md"]
+
+def test_extract_example_paths_multiple():
+    text = (
+        "* [a](../examples/a.md) — desc\n"
+        "* [b](../examples/b.md) — desc\n"
+    )
+    result = vec._extract_example_paths(text)
+    assert "examples/a.md" in result
+    assert "examples/b.md" in result
+    assert len(result) == 2
+
+def test_extract_example_paths_ignores_non_examples():
+    text = "* [skills/foo.md](../skills/foo.md) — not an example"
+    assert vec._extract_example_paths(text) == []
+
+def test_extract_example_paths_empty_section():
+    assert vec._extract_example_paths("") == []
+
+
+# ── Malformed item detection ───────────────────────────────────────────────────
+
+def test_find_malformed_items_clean():
+    text = "* [examples/foo.md](../examples/foo.md) — description"
+    assert vec._find_malformed_items(text) == []
+
+def test_find_malformed_items_no_link():
+    text = "* some description without a link"
+    result = vec._find_malformed_items(text)
+    assert len(result) == 1
+    assert "some description without a link" in result[0]
+
+def test_find_malformed_items_dash_prefix():
+    text = "- some item without a link"
+    assert len(vec._find_malformed_items(text)) == 1
+
+def test_find_malformed_items_blank_lines_ok():
+    text = "\n\n* [examples/foo.md](../examples/foo.md) — ok\n\n"
+    assert vec._find_malformed_items(text) == []
+
+def test_find_malformed_items_non_list_lines_ok():
+    text = "Some intro text\n* [examples/foo.md](../examples/foo.md) — ok"
+    assert vec._find_malformed_items(text) == []
+
+def test_find_malformed_items_link_to_wrong_dir():
+    text = "* [sources/foo.md](../sources/foo.md) — wrong dir"
+    assert len(vec._find_malformed_items(text)) == 1
+
+
+# ── parse_skill ────────────────────────────────────────────────────────────────
+
+def test_parse_skill_with_valid_section(tmp_path):
+    skill = tmp_path / "labor-law-analysis.md"
+    _write_skill_with_examples(skill, ["examples/labor-dispute.md"])
+    has_section, paths, malformed = vec.parse_skill(skill)
+    assert has_section
+    assert "examples/labor-dispute.md" in paths
+    assert malformed == []
+
+def test_parse_skill_no_section(tmp_path):
+    skill = tmp_path / "skill.md"
+    _write_skill_no_section(skill)
+    has_section, paths, malformed = vec.parse_skill(skill)
+    assert not has_section
+    assert paths == []
+    assert malformed == []
+
+def test_parse_skill_malformed_item(tmp_path):
+    skill = tmp_path / "skill.md"
+    _write_skill_malformed_item(skill)
+    has_section, paths, malformed = vec.parse_skill(skill)
+    assert has_section
+    assert paths == []
+    assert len(malformed) == 1
+
+def test_parse_skill_arabic_heading(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## أمثلة مرتبطة\n\n"
+        "* [examples/foo.md](../examples/foo.md) — description\n",
+        encoding="utf-8",
+    )
+    has_section, paths, _ = vec.parse_skill(skill)
+    assert has_section
+    assert "examples/foo.md" in paths
+
+def test_parse_skill_empty_section(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Related examples / أمثلة مرتبطة\n\n## Next Section\n",
+        encoding="utf-8",
+    )
+    has_section, paths, malformed = vec.parse_skill(skill)
+    assert has_section
+    assert paths == []
+    assert malformed == []
+
+def test_parse_skill_section_not_bleed_into_next(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Related examples / أمثلة مرتبطة\n\n"
+        "* [examples/foo.md](../examples/foo.md) — ok\n\n"
+        "## Next Section\n"
+        "* [examples/bar.md](../examples/bar.md) — should not appear\n",
+        encoding="utf-8",
+    )
+    _, paths, _ = vec.parse_skill(skill)
+    assert "examples/foo.md" in paths
+    assert "examples/bar.md" not in paths
+
+
+# ── coverage_status ────────────────────────────────────────────────────────────
+
+def test_coverage_status_missing():
+    assert vec.coverage_status(0) == "Missing"
+
+def test_coverage_status_partial():
+    assert vec.coverage_status(1) == "Partial"
+
+def test_coverage_status_strong_two():
+    assert vec.coverage_status(2) == "Strong"
+
+def test_coverage_status_strong_many():
+    assert vec.coverage_status(5) == "Strong"
+```
+
+- [ ] **Step 1.2: Run tests to confirm they fail**
+
+```bash
+pytest tests/test_validate_example_coverage.py -v
+```
+
+Expected: `ImportError: No module named 'validate_example_coverage'` (all tests fail to import)
+
+- [ ] **Step 1.3: Create the script with all core functions**
+
+Create `scripts/validate_example_coverage.py` with this content (stop before `run_checks` and `main` — those come in Task 2):
+
+```python
+#!/usr/bin/env python3
+"""
+validate_example_coverage.py
+Saudi Legal AI Framework — skill → example coverage validator
+
+Checks that every skills/*.md file has a ## Related examples section and that
+all referenced example files exist on disk.
+
+Usage:
+    python scripts/validate_example_coverage.py          # validate
+    python scripts/validate_example_coverage.py --fix    # auto-fix (not yet implemented)
+
+Exit codes: 0 = pass, 1 = errors found
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+EXAMPLES_DIR = REPO_ROOT / "examples"
+CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"
+
+# Heading aliases — add future multilingual aliases here.
+# Matching is case-insensitive and strips leading #, digits, §, and whitespace.
+RELATED_EXAMPLES_HEADING_ALIASES = [
+    "related examples",
+    "أمثلة مرتبطة",
+]
+
+COVERAGE_STRONG = 2
+COVERAGE_PARTIAL = 1
+
+
+def _normalize_heading(line: str) -> str:
+    """Strip leading #, section numbers (11., §11), and lowercase."""
+    text = re.sub(r"^#+\s*", "", line)
+    text = re.sub(r"^\d+\.\s*", "", text)
+    text = re.sub(r"§\d+\s*", "", text)
+    return text.strip().lower()
+
+
+def _is_related_examples_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in RELATED_EXAMPLES_HEADING_ALIASES)
+
+
+def _heading_level(line: str) -> int:
+    m = re.match(r"^(#+)", line)
+    return len(m.group(1)) if m else 0
+
+
+def _extract_section(lines: list, heading_predicate) -> str:
+    """Return the text body of the first section matching heading_predicate."""
+    in_section = False
+    section_level = 0
+    body: list = []
+    for line in lines:
+        if not in_section:
+            if line.startswith("#") and heading_predicate(line):
+                in_section = True
+                section_level = _heading_level(line)
+        else:
+            lvl = _heading_level(line)
+            if line.startswith("#") and lvl <= section_level:
+                break
+            body.append(line)
+    return "\n".join(body)
+
+
+def _has_section_heading(lines: list, heading_predicate) -> bool:
+    """Return True if any line is a heading matching heading_predicate."""
+    return any(
+        line.startswith("#") and heading_predicate(line)
+        for line in lines
+    )
+
+
+def _extract_example_paths(section_text: str) -> list:
+    """
+    Return list of example path strings (relative to repo root, e.g. 'examples/foo.md')
+    from markdown links in the section. Accepts both '../examples/foo.md' and
+    'examples/foo.md' forms.
+    """
+    paths = []
+    for m in re.finditer(r"\[([^\]]*)\]\(([^)]+)\)", section_text):
+        raw_path = m.group(2)
+        normalized = re.sub(r"^\.\./", "", raw_path)
+        if normalized.startswith("examples/"):
+            paths.append(normalized)
+    return paths
+
+
+def _find_malformed_items(section_text: str) -> list:
+    """
+    Return list of bullet items (lines starting with * or -) that contain no
+    markdown link whose path resolves to examples/. These are structurally
+    malformed entries that should be fixed.
+    """
+    malformed = []
+    for line in section_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith(("*", "-")):
+            continue
+        has_example_link = bool(
+            re.search(r"\[([^\]]*)\]\(\.\./examples/[\w.-]+\)", stripped)
+            or re.search(r"\[([^\]]*)\]\(examples/[\w.-]+\)", stripped)
+        )
+        if not has_example_link:
+            malformed.append(stripped)
+    return malformed
+
+
+def parse_skill(path: Path) -> tuple:
+    """
+    Parse a skill file for its Related examples section.
+
+    Returns (has_section, example_paths, malformed_items):
+    - has_section: True if a ## Related examples heading was found
+    - example_paths: list of normalized paths like 'examples/foo.md'
+    - malformed_items: bullet items without a valid examples/ link
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    has_section = _has_section_heading(lines, _is_related_examples_heading)
+    if not has_section:
+        return False, [], []
+    section_text = _extract_section(lines, _is_related_examples_heading)
+    return True, _extract_example_paths(section_text), _find_malformed_items(section_text)
+
+
+def coverage_status(count: int) -> str:
+    """Return 'Strong', 'Partial', or 'Missing' based on example count."""
+    if count >= COVERAGE_STRONG:
+        return "Strong"
+    if count == COVERAGE_PARTIAL:
+        return "Partial"
+    return "Missing"
+```
+
+- [ ] **Step 1.4: Run unit tests — expect them to pass**
+
+```bash
+pytest tests/test_validate_example_coverage.py -v -k "not run_checks"
+```
+
+Expected: all unit tests PASS (the `run_checks` integration tests will fail — that's fine, they're excluded)
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add scripts/validate_example_coverage.py tests/test_validate_example_coverage.py
+git commit -m "feat: add validate_example_coverage.py core functions and unit tests"
+```
+
+---
+
+## Task 2: `run_checks`, `main`, and Integration Tests
+
+**Files:**
+- Modify: `scripts/validate_example_coverage.py` (append `run_checks` and `main`)
+- Modify: `tests/test_validate_example_coverage.py` (append integration tests — already written in Task 1)
+
+- [ ] **Step 2.1: Run the integration tests to confirm they fail**
+
+```bash
+pytest tests/test_validate_example_coverage.py -v -k "run_checks"
+```
+
+Expected: `AttributeError: module 'validate_example_coverage' has no attribute 'run_checks'`
+
+- [ ] **Step 2.2: Append `run_checks` and `main` to the script**
+
+Append this to the end of `scripts/validate_example_coverage.py`:
+
+```python
+
+def run_checks(
+    skills_dir: Path = SKILLS_DIR,
+    examples_dir: Path = EXAMPLES_DIR,
+    cross_ref_map: Path = CROSS_REF_MAP,
+) -> tuple:
+    """
+    Run all checks. Returns (errors, warnings).
+    errors   → CI-blocking (broken paths, malformed sections)
+    warnings → non-blocking (missing sections, zero coverage, map drift)
+
+    Check 1: Malformed bullet item in Related examples section
+    Check 2: Referenced example file does not exist on disk
+    Check 3: Skill has no ## Related examples section
+    Check 4: Skill has 0 valid examples listed
+    Check 5: cross-reference-map.md coverage table missing a row for this skill
+    """
+    errors: list = []
+    warnings: list = []
+
+    for d in (skills_dir, examples_dir):
+        if not d.exists():
+            errors.append(f"ERROR: required directory not found: {d}")
+    if errors:
+        return errors, warnings
+
+    map_text = cross_ref_map.read_text(encoding="utf-8") if cross_ref_map.exists() else ""
+
+    for skill_file in sorted(skills_dir.glob("*.md")):
+        skill_path = f"skills/{skill_file.name}"
+        has_section, example_paths, malformed = parse_skill(skill_file)
+
+        # Check 3: No section at all
+        if not has_section:
+            warnings.append(
+                f"WARNING: {skill_path} has no '## Related examples' section."
+            )
+            continue
+
+        # Check 1: Malformed items
+        for item in malformed:
+            errors.append(
+                f"ERROR: {skill_path} 'Related examples': malformed list item: {item!r}"
+            )
+
+        # Check 2: Broken paths
+        for ex_path in example_paths:
+            if not (examples_dir.parent / ex_path).exists():
+                errors.append(
+                    f"ERROR: {skill_path} references {ex_path} but file not found."
+                )
+
+        # Check 4: Zero coverage (section present but lists nothing valid)
+        valid_paths = [p for p in example_paths if (examples_dir.parent / p).exists()]
+        if len(valid_paths) == 0:
+            warnings.append(
+                f"WARNING: {skill_path} 'Related examples' lists 0 valid examples."
+            )
+
+        # Check 5: Map drift
+        row_present = (skill_path in map_text) and ("Example Coverage" in map_text)
+        if not row_present:
+            warnings.append(
+                f"WARNING: cross-reference-map.md 'Skill → Example Coverage' "
+                f"may be missing row for {skill_path}."
+            )
+
+    return errors, warnings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate skill→example coverage in skills/."
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix missing Related examples sections (not yet implemented).",
+    )
+    args = parser.parse_args()
+
+    if args.fix:
+        print("--fix mode is not yet implemented.")
+        sys.exit(0)
+
+    errors, warnings = run_checks()
+
+    for w in warnings:
+        print(w)
+    for e in errors:
+        print(e)
+
+    if not errors and not warnings:
+        print("✓ All example coverage checks passed.")
+    elif not errors:
+        print("✓ No errors. See warnings above.")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2.3: Append the integration tests to the test file**
+
+Append this block to the end of `tests/test_validate_example_coverage.py`:
+
+```python
+
+# ── run_checks integration ─────────────────────────────────────────────────────
+
+def _make_dirs(tmp_path):
+    skills_dir = tmp_path / "skills"
+    examples_dir = tmp_path / "examples"
+    skills_dir.mkdir()
+    examples_dir.mkdir()
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    return skills_dir, examples_dir, docs_dir
+
+
+def test_run_checks_passes_all_valid(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text(
+        "## Skill → Example Coverage\n"
+        "| `skills/labor-law-analysis.md` | 1 | ... | Partial |\n",
+        encoding="utf-8",
+    )
+    _write_example(examples_dir / "labor-dispute.md")
+    _write_skill_with_examples(
+        skills_dir / "labor-law-analysis.md",
+        ["examples/labor-dispute.md"],
+    )
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert errors == []
+    assert warnings == []
+
+
+def test_run_checks_check1_malformed_item_is_error(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    _write_skill_malformed_item(skills_dir / "skill.md")
+    errors, _ = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert any("malformed" in e for e in errors)
+
+
+def test_run_checks_check2_broken_path_is_error(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    _write_skill_with_examples(
+        skills_dir / "skill.md",
+        ["examples/does-not-exist.md"],
+    )
+    errors, _ = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert any("not found" in e for e in errors)
+
+
+def test_run_checks_check3_no_section_is_warning(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    _write_skill_no_section(skills_dir / "skill.md")
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert errors == []
+    assert any("no '## Related examples'" in w for w in warnings)
+
+
+def test_run_checks_check4_zero_examples_is_warning(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    (skills_dir / "skill.md").write_text(
+        "## Related examples / أمثلة مرتبطة\n\n## Next\n",
+        encoding="utf-8",
+    )
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert errors == []
+    assert any("0 valid examples" in w for w in warnings)
+
+
+def test_run_checks_check5_map_missing_row_is_warning(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text(
+        "## Skill → Example Coverage\n| some-other-skill | ...\n",
+        encoding="utf-8",
+    )
+    _write_example(examples_dir / "example.md")
+    _write_skill_with_examples(skills_dir / "skill.md", ["examples/example.md"])
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert errors == []
+    assert any("cross-reference-map" in w for w in warnings)
+
+
+def test_run_checks_missing_skills_dir_is_error(tmp_path):
+    errors, _ = vec.run_checks(
+        tmp_path / "nonexistent-skills",
+        tmp_path / "examples",
+        tmp_path / "map.md",
+    )
+    assert any("not found" in e for e in errors)
+
+
+def test_run_checks_broken_path_does_not_produce_warning_for_missing_section(tmp_path):
+    """Check 2 error does not suppress Check 3 warning for other skills."""
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    # skill-a has bad path → error
+    _write_skill_with_examples(skills_dir / "skill-a.md", ["examples/missing.md"])
+    # skill-b has no section → warning
+    _write_skill_no_section(skills_dir / "skill-b.md")
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert any("missing.md" in e for e in errors)
+    assert any("skill-b.md" in w for w in warnings)
+```
+
+- [ ] **Step 2.4: Run all tests**
+
+```bash
+pytest tests/test_validate_example_coverage.py -v
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 2.5: Run the script manually against the real repo (expect warnings — no errors)**
+
+```bash
+python3 scripts/validate_example_coverage.py
+```
+
+Expected output (warnings only, no errors, exit code 0):
+```
+WARNING: skills/arbitration.md has no '## Related examples' section.
+WARNING: skills/commercial-dispute.md has no '## Related examples' section.
+WARNING: skills/compliance-check.md has no '## Related examples' section.
+WARNING: skills/contract-review.md has no '## Related examples' section.
+WARNING: skills/labor-law-analysis.md has no '## Related examples' section.
+WARNING: skills/legal-drafting.md has no '## Related examples' section.
+WARNING: skills/real-estate-contracts.md has no '## Related examples' section.
+✓ No errors. See warnings above.
+```
+
+Exit code: `0` (warnings are non-blocking; confirm with `echo $?`)
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add scripts/validate_example_coverage.py tests/test_validate_example_coverage.py
+git commit -m "feat: add run_checks and integration tests for validate_example_coverage"
+```
+
+---
+
+## Task 3: Add `## Related examples` Sections to All 7 Skill Files
+
+**Files:** Modify all 7 files under `skills/` — append a new section at the end of each.
+
+The canonical format (per spec) is:
+```
+* [examples/filename.md](../examples/filename.md) — one-line scenario description
+```
+
+- [ ] **Step 3.1: Append to `skills/arbitration.md`**
+
+Append this exact block at the very end of the file (after the last line of §14):
+
+```markdown
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/arbitration-example.md](../examples/arbitration-example.md) — cross-border supply dispute: enforcing a DIAC arbitration clause under Saudi law
+```
+
+- [ ] **Step 3.2: Append to `skills/commercial-dispute.md`**
+
+```markdown
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/commercial-dispute-example.md](../examples/commercial-dispute-example.md) — commercial dispute analysis under Saudi commercial courts framework
+```
+
+- [ ] **Step 3.3: Append to `skills/compliance-check.md`**
+
+```markdown
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/compliance-example.md](../examples/compliance-example.md) — SaaS startup compliance assessment (PDPL, Nitaqat, WPS)
+* [examples/pdpl-data-breach-example.md](../examples/pdpl-data-breach-example.md) — medical data breach: PDPL notification obligations and response workflow
+```
+
+- [ ] **Step 3.4: Append to `skills/contract-review.md`**
+
+```markdown
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/contract-review-example.md](../examples/contract-review-example.md) — professional services contract review: foreign governing law clause, interest, IP transfer
+* [examples/employment-contract-review.md](../examples/employment-contract-review.md) — employment contract review: Saudi national, full §8 output demonstration
+* [examples/nda-review.md](../examples/nda-review.md) — NDA review: confidentiality scope, PDPL alignment, enforceability
+* [examples/saudi-contract-review-demo.md](../examples/saudi-contract-review-demo.md) — full 9-section contract review workflow demo (authoritative §8 reference)
+```
+
+- [ ] **Step 3.5: Append to `skills/labor-law-analysis.md`**
+
+```markdown
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/employment-contract-review.md](../examples/employment-contract-review.md) — employment contract review: mandatory elements check under Saudi Labour Law
+* [examples/labor-dispute-job-change-example.md](../examples/labor-dispute-job-change-example.md) — unilateral job title and salary change without employee consent
+* [examples/labor-law-example.md](../examples/labor-law-example.md) — EOSB calculation and wrongful termination analysis (7-year employee)
+```
+
+- [ ] **Step 3.6: Append to `skills/legal-drafting.md`**
+
+```markdown
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/legal-drafting-example.md](../examples/legal-drafting-example.md) — software services contract drafting: milestone-linked payments, IP, PDPL clauses
+```
+
+- [ ] **Step 3.7: Append to `skills/real-estate-contracts.md`**
+
+```markdown
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/commercial-lease-exit-example.md](../examples/commercial-lease-exit-example.md) — early exit from commercial lease: penalty clause enforceability
+* [examples/real-estate-example.md](../examples/real-estate-example.md) — residential lease renewal dispute: Ejar platform registration and rent increase limits
+```
+
+- [ ] **Step 3.8: Run the validator — expect warnings only for map drift (no missing-section warnings)**
+
+```bash
+python3 scripts/validate_example_coverage.py
+```
+
+Expected output (all 7 skills covered, warnings only about missing map rows):
+```
+WARNING: cross-reference-map.md 'Skill → Example Coverage' may be missing row for skills/arbitration.md.
+WARNING: cross-reference-map.md 'Skill → Example Coverage' may be missing row for skills/commercial-dispute.md.
+... (one per skill)
+✓ No errors. See warnings above.
+```
+
+Exit code: `0`
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add skills/arbitration.md skills/commercial-dispute.md skills/compliance-check.md \
+        skills/contract-review.md skills/labor-law-analysis.md \
+        skills/legal-drafting.md skills/real-estate-contracts.md
+git commit -m "docs: add Related examples sections to all 7 skill files"
+```
+
+---
+
+## Task 4: Update `docs/cross-reference-map.md`
+
+**Files:** Modify `docs/cross-reference-map.md`
+
+Two changes:
+1. Fix stale §3 (Skills ← → Examples) — it shows `compliance-check.md`, `legal-drafting.md`, and `commercial-dispute.md` as having no examples, which is now wrong.
+2. Add new `## Skill → Example Coverage` section between §3 and §4.
+
+- [ ] **Step 4.1: Replace the stale §3 table**
+
+Find this block in `docs/cross-reference-map.md`:
+
+```markdown
+## 3. Skills ← → Examples / المهارات ← → الأمثلة التطبيقية
+
+| Skill | Related Examples | ملاحظة |
+|---|---|---|
+| `skills/contract-review.md` | `examples/employment-contract-review.md` · `examples/nda-review.md` · `examples/saudi-contract-review-demo.md` | الـ demo هو التطبيق الكامل لـ §8 |
+| `skills/labor-law-analysis.md` | `examples/employment-contract-review.md` | المثال يُطبِّق تحليل نظام العمل |
+| `skills/commercial-dispute.md` | — | لا يوجد مثال تطبيقي بعد |
+| `skills/compliance-check.md` | — | لا يوجد مثال تطبيقي بعد |
+| `skills/legal-drafting.md` | — | لا يوجد مثال تطبيقي بعد |
+```
+
+Replace with:
+
+```markdown
+## 3. Skills ← → Examples / المهارات ← → الأمثلة التطبيقية
+
+| Skill | Related Examples | ملاحظة |
+|---|---|---|
+| `skills/arbitration.md` | `examples/arbitration-example.md` | نزاع توريد عابر للحدود |
+| `skills/commercial-dispute.md` | `examples/commercial-dispute-example.md` | تحليل نزاع تجاري |
+| `skills/compliance-check.md` | `examples/compliance-example.md` · `examples/pdpl-data-breach-example.md` | فحص امتثال SaaS + اختراق بيانات طبية |
+| `skills/contract-review.md` | `examples/contract-review-example.md` · `examples/employment-contract-review.md` · `examples/nda-review.md` · `examples/saudi-contract-review-demo.md` | الـ demo هو التطبيق الكامل لـ §8 |
+| `skills/labor-law-analysis.md` | `examples/employment-contract-review.md` · `examples/labor-dispute-job-change-example.md` · `examples/labor-law-example.md` | يتضمن حساب EOSB ونزاع تغيير المسمى |
+| `skills/legal-drafting.md` | `examples/legal-drafting-example.md` | صياغة عقد خدمات برمجيات |
+| `skills/real-estate-contracts.md` | `examples/commercial-lease-exit-example.md` · `examples/real-estate-example.md` | إيجار تجاري + سكني |
+```
+
+- [ ] **Step 4.2: Insert the new `## Skill → Example Coverage` section**
+
+After the `---` separator that follows §3, insert this new section (before the current `## 4. Sources ← → Regulations` heading):
+
+```markdown
+## Skill → Example Coverage
+
+> هذا الجدول مُولَّد من `## Related examples` في كل ملف `skills/*.md`.
+> يُشغَّل `scripts/validate_example_coverage.py` في كل push للتحقق منه.
+> This table is derived from `## Related examples` in each `skills/*.md` file.
+> `scripts/validate_example_coverage.py` runs on every push to verify it.
+
+| Skill | Example Count | Example Files | Coverage Status |
+|---|---|---|---|
+| `skills/arbitration.md` | 1 | `examples/arbitration-example.md` | Partial |
+| `skills/commercial-dispute.md` | 1 | `examples/commercial-dispute-example.md` | Partial |
+| `skills/compliance-check.md` | 2 | `examples/compliance-example.md` · `examples/pdpl-data-breach-example.md` | Strong |
+| `skills/contract-review.md` | 4 | `examples/contract-review-example.md` · `examples/employment-contract-review.md` · `examples/nda-review.md` · `examples/saudi-contract-review-demo.md` | Strong |
+| `skills/labor-law-analysis.md` | 3 | `examples/employment-contract-review.md` · `examples/labor-dispute-job-change-example.md` · `examples/labor-law-example.md` | Strong |
+| `skills/legal-drafting.md` | 1 | `examples/legal-drafting-example.md` | Partial |
+| `skills/real-estate-contracts.md` | 2 | `examples/commercial-lease-exit-example.md` · `examples/real-estate-example.md` | Strong |
+
+**Coverage rules:** 0 examples → Missing | 1 example → Partial | 2+ examples → Strong
+
+---
+
+```
+
+Also update the "Last updated" line at the bottom of the file:
+```
+*آخر تحديث / Last updated: 2026-05-25 — إضافة § Skill → Example Coverage + تحديث §3 + validate_example_coverage.py*
+```
+
+- [ ] **Step 4.3: Run the full validator — expect zero errors and zero warnings**
+
+```bash
+python3 scripts/validate_example_coverage.py
+```
+
+Expected:
+```
+✓ All example coverage checks passed.
+```
+
+Exit code: `0` (confirm with `echo $?`)
+
+- [ ] **Step 4.4: Run the cross-refs validator — confirm it still passes**
+
+```bash
+python3 scripts/validate_cross_refs.py
+```
+
+Expected: `✓ All cross-reference checks passed.` or `✓ No errors.`
+
+- [ ] **Step 4.5: Run the full test suite**
+
+```bash
+pytest
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add docs/cross-reference-map.md
+git commit -m "docs: add Skill → Example Coverage section and fix stale §3 in cross-reference-map"
+```
+
+---
+
+## Task 5: Wire Validator into CI
+
+**Files:** Modify `.github/workflows/validate-datasets.yml`
+
+- [ ] **Step 5.1: Add the new CI step**
+
+In `.github/workflows/validate-datasets.yml`, find:
+
+```yaml
+      - name: Validate cross-references
+        run: python3 scripts/validate_cross_refs.py
+```
+
+Replace with:
+
+```yaml
+      - name: Validate cross-references
+        run: python3 scripts/validate_cross_refs.py
+
+      - name: Validate example coverage
+        run: python3 scripts/validate_example_coverage.py
+```
+
+- [ ] **Step 5.2: Run pytest to confirm the full suite still passes**
+
+```bash
+pytest
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 5.3: Dry-run both validators**
+
+```bash
+python3 scripts/validate_cross_refs.py && python3 scripts/validate_example_coverage.py
+```
+
+Expected: both print `✓ ...` and exit 0.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add .github/workflows/validate-datasets.yml
+git commit -m "ci: add validate_example_coverage.py step after validate_cross_refs.py"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- [x] §1 — `## Related examples` section added to every skill file (Task 3)
+- [x] §2 — `## Skill → Example Coverage` table added to cross-reference-map.md (Task 4)
+- [x] §3 — `scripts/validate_example_coverage.py` with all 5 checks (Task 2)
+- [x] §4 — `tests/test_validate_example_coverage.py` with unit + integration tests (Tasks 1–2)
+- [x] §5 — CI wiring after `validate_cross_refs.py` (Task 5)
+- [x] Architecture requirements — alias-based heading detection, same coding style as validate_cross_refs.py, `--fix` stub, future multilingual alias support, no hardcoded section numbers
+
+**Placeholder scan:** No TBD, TODO, or "similar to" references found.
+
+**Type consistency:**
+- `parse_skill(path)` → `(bool, list[str], list[str])` — used consistently in Tasks 1 and 2
+- `run_checks(skills_dir, examples_dir, cross_ref_map)` → `(list[str], list[str])` — matches test expectations
+- `coverage_status(count: int)` → `str` — used only in documentation, not checked by validator (table is maintained manually)
+
+**Rollout sequence:** validator-first → docs-last → CI-last. At no point does CI block on a condition that doesn't yet pass.

--- a/docs/superpowers/plans/2026-05-25-skill-relationship-graph.md
+++ b/docs/superpowers/plans/2026-05-25-skill-relationship-graph.md
@@ -1,0 +1,1310 @@
+# Skill Relationship Graph Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a typed, bidirectional skill relationship graph to the Saudi Legal AI Framework so skills are a navigable legal reasoning network rather than isolated documents.
+
+**Architecture:** Each `skills/*.md` file gets a `## Related skills / مهارات مرتبطة` section using a 3-line-per-edge format (path, typed relationship, rationale). A new validator `scripts/validate_skill_graph.py` parses these sections, validates structure and types, detects self-references and orphans, and emits graph statistics to stdout on every CI run.
+
+**Tech Stack:** Python 3.11, pytest, pathlib, re, dataclasses — no external dependencies. Same pattern as `validate_cross_refs.py` and `validate_example_coverage.py`.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `scripts/validate_skill_graph.py` | Validator: parsing, checks, stats |
+| Create | `tests/test_validate_skill_graph.py` | ~31 unit + integration tests |
+| Modify | `skills/arbitration.md` | Add `## Related skills` section |
+| Modify | `skills/commercial-dispute.md` | Add `## Related skills` section |
+| Modify | `skills/compliance-check.md` | Add `## Related skills` section |
+| Modify | `skills/contract-review.md` | Add `## Related skills` section |
+| Modify | `skills/labor-law-analysis.md` | Add `## Related skills` section |
+| Modify | `skills/legal-drafting.md` | Add `## Related skills` section |
+| Modify | `skills/real-estate-contracts.md` | Add `## Related skills` section |
+| Modify | `docs/cross-reference-map.md` | Add `## Skill Relationship Graph` table |
+| Modify | `.github/workflows/validate-datasets.yml` | Add CI step after example coverage |
+
+## Edge Map (14 directed edges, 7 nodes)
+
+The authoritative relationship list. Every `## Related skills` section in Task 3 is derived from this table.
+
+| Source | Target | Type | Rationale |
+|--------|--------|------|-----------|
+| `contract-review` | `commercial-dispute` | `escalates_to` | Unresolved contract breach or contested clause may require Commercial Court proceedings |
+| `contract-review` | `arbitration` | `escalates_to` | An arbitration clause in the contract activates this path instead of court litigation |
+| `contract-review` | `legal-drafting` | `precedes` | Review identifies gaps and red flags; legal-drafting addresses them |
+| `contract-review` | `compliance-check` | `cross_checks` | Contracts containing PDPL clauses, Nitaqat obligations, or WPS terms need compliance verification |
+| `real-estate-contracts` | `contract-review` | `specializes` | Real estate contracts are a domain-scoped application of the general contract review methodology |
+| `real-estate-contracts` | `compliance-check` | `depends_on` | Ejar registration, municipal approvals, and REGA requirements are compliance obligations |
+| `commercial-dispute` | `arbitration` | `alternative_to` | Arbitration replaces court litigation when a valid arbitration clause exists or parties agree |
+| `commercial-dispute` | `legal-drafting` | `precedes` | Formal demand notices must be drafted before court filing |
+| `arbitration` | `commercial-dispute` | `alternative_to` | Court litigation is the fallback when arbitration is excluded, waived, or fails |
+| `arbitration` | `legal-drafting` | `depends_on` | Arbitration requests, submissions, and award enforcement filings require legal drafting |
+| `compliance-check` | `labor-law-analysis` | `cross_checks` | Nitaqat, WPS, and GOSI compliance are labor law sub-domains requiring cross-verification |
+| `labor-law-analysis` | `compliance-check` | `cross_checks` | Employment compliance dimensions (PDPL over HR data, Saudization quotas) cross both domains |
+| `labor-law-analysis` | `contract-review` | `depends_on` | Employment contracts are analysed using the contract-review methodology for clause-level risk |
+| `legal-drafting` | `contract-review` | `depends_on` | Quality criteria for drafted documents are grounded in contract-review red flags and mandatory clause checklists |
+
+**Degree summary (total = in + out):**
+- `contract-review`: 7 (4 out, 3 in) — most connected
+- `commercial-dispute`: 4 (2 out, 2 in)
+- `arbitration`: 4 (2 out, 2 in)
+- `compliance-check`: 4 (1 out, 3 in)
+- `legal-drafting`: 4 (1 out, 3 in)
+- `labor-law-analysis`: 3 (2 out, 1 in)
+- `real-estate-contracts`: 2 (2 out, 0 in)
+
+**Note on W3 (asymmetric) warnings:** ~8 of the 14 edges are intentionally one-directional (e.g., `specializes` and `escalates_to` do not require reverse edges). The validator will emit W3 warnings for each of these on clean runs. These are informational and non-blocking. Export flags (JSON/DOT/Mermaid) are deliberately excluded from this PR; follow-up PR after graph is stable.
+
+---
+
+## Task 1: Core parsing functions + unit tests (TDD)
+
+**Files:**
+- Create: `scripts/validate_skill_graph.py` (constants, `Edge` dataclass, 8 parsing functions)
+- Create: `tests/test_validate_skill_graph.py` (20 unit tests for Task 1 functions)
+
+No `run_checks` or `main` yet — only the pure parsing layer.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_validate_skill_graph.py`:
+
+```python
+# tests/test_validate_skill_graph.py
+"""Tests for scripts/validate_skill_graph.py — Saudi Legal AI Framework"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import validate_skill_graph as vsg
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────────
+
+def _write_skill_with_edges(path: Path, edges: list) -> None:
+    """Write a skill file with a properly-formed Related skills section.
+
+    edges: list of (target_path, relationship_type, rationale) tuples
+           e.g. ("skills/foo.md", "escalates_to", "some reason")
+    """
+    items = []
+    for target, rel_type, rationale in edges:
+        items.append(
+            f"* [{target}](../{target})\n"
+            f"  — relationship: {rel_type}\n"
+            f"  — {rationale}"
+        )
+    body = "\n\n".join(items)
+    path.write_text(
+        "## Introduction\nIntro.\n\n"
+        "## Related skills / مهارات مرتبطة\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_no_section(path: Path) -> None:
+    path.write_text(
+        "## Introduction\nIntro.\n\n## 11. Relevant Regulations\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_malformed_item(path: Path) -> None:
+    path.write_text(
+        "## Related skills / مهارات مرتبطة\n\n"
+        "* some description without a link\n",
+        encoding="utf-8",
+    )
+
+
+# ── Heading detection ────────────────────────────────────────────────────────────
+
+def test_normalize_heading_strips_hashes():
+    assert vsg._normalize_heading("## Related skills") == "related skills"
+
+def test_normalize_heading_arabic():
+    assert vsg._normalize_heading("## مهارات مرتبطة") == "مهارات مرتبطة"
+
+def test_normalize_heading_strips_section_number():
+    assert vsg._normalize_heading("## 15. Related skills") == "related skills"
+
+def test_is_related_skills_heading_bilingual():
+    assert vsg._is_related_skills_heading("## Related skills / مهارات مرتبطة")
+
+def test_is_related_skills_heading_arabic_only():
+    assert vsg._is_related_skills_heading("## مهارات مرتبطة")
+
+def test_is_related_skills_heading_case_insensitive():
+    assert vsg._is_related_skills_heading("## RELATED SKILLS")
+
+def test_is_related_skills_heading_unrelated():
+    assert not vsg._is_related_skills_heading("## Related examples")
+
+def test_is_related_skills_heading_unrelated_arabic():
+    assert not vsg._is_related_skills_heading("## الأنظمة ذات الصلة")
+
+
+# ── Edge extraction ──────────────────────────────────────────────────────────────
+
+VALID_EDGE_SECTION = (
+    "* [commercial-dispute.md](../skills/commercial-dispute.md)\n"
+    "  — relationship: escalates_to\n"
+    "  — a contract dispute may require Commercial Court proceedings\n"
+)
+
+def test_extract_skill_edges_single_valid_edge():
+    edges = vsg._extract_skill_edges(VALID_EDGE_SECTION)
+    assert len(edges) == 1
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert edges[0].relationship == "escalates_to"
+    assert "contract dispute" in edges[0].rationale
+
+def test_extract_skill_edges_multiple_edges():
+    section = (
+        "* [commercial-dispute.md](../skills/commercial-dispute.md)\n"
+        "  — relationship: escalates_to\n"
+        "  — breach may lead to litigation\n"
+        "\n"
+        "* [arbitration.md](../skills/arbitration.md)\n"
+        "  — relationship: escalates_to\n"
+        "  — arbitration clause may activate this path\n"
+    )
+    edges = vsg._extract_skill_edges(section)
+    assert len(edges) == 2
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert edges[1].target == "skills/arbitration.md"
+
+def test_extract_skill_edges_normalizes_dotdot_prefix():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: depends_on\n"
+        "  — rationale\n"
+    )
+    edges = vsg._extract_skill_edges(section)
+    assert edges[0].target == "skills/foo.md"
+
+def test_extract_skill_edges_no_links_returns_empty():
+    assert vsg._extract_skill_edges("no links here\n* plain bullet\n") == []
+
+def test_extract_skill_edges_missing_relationship_line_skips_entry():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  just some text without relationship:\n"
+        "  — rationale\n"
+    )
+    assert vsg._extract_skill_edges(section) == []
+
+
+# ── Malformed entry detection ─────────────────────────────────────────────────────
+
+def test_find_malformed_entries_clean_returns_empty():
+    assert vsg._find_malformed_entries(VALID_EDGE_SECTION) == []
+
+def test_find_malformed_entries_no_link():
+    section = "* some text without a skills link\n"
+    result = vsg._find_malformed_entries(section)
+    assert len(result) == 1
+    assert "some text" in result[0]
+
+def test_find_malformed_entries_missing_relationship_line():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — just rationale without relationship line\n"
+    )
+    assert len(vsg._find_malformed_entries(section)) == 1
+
+def test_find_malformed_entries_missing_rationale_line():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: escalates_to\n"
+    )
+    assert len(vsg._find_malformed_entries(section)) == 1
+
+
+# ── parse_skill ──────────────────────────────────────────────────────────────────
+
+def test_parse_skill_with_valid_section(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_with_edges(f, [
+        ("skills/commercial-dispute.md", "escalates_to", "breach may lead to litigation"),
+    ])
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert has_section
+    assert len(edges) == 1
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert malformed == []
+
+def test_parse_skill_no_section(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_no_section(f)
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert not has_section
+    assert edges == []
+    assert malformed == []
+
+def test_parse_skill_malformed_entry(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_malformed_item(f)
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert has_section
+    assert edges == []
+    assert len(malformed) == 1
+
+def test_parse_skill_arabic_heading(tmp_path):
+    f = tmp_path / "myskill.md"
+    f.write_text(
+        "## مهارات مرتبطة\n\n"
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: depends_on\n"
+        "  — rationale text\n",
+        encoding="utf-8",
+    )
+    has_section, edges, _ = vsg.parse_skill(f)
+    assert has_section
+    assert len(edges) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python3 -m pytest tests/test_validate_skill_graph.py -v 2>&1 | head -20
+```
+
+Expected: `ModuleNotFoundError: No module named 'validate_skill_graph'`
+
+- [ ] **Step 3: Write the implementation (core functions only)**
+
+Create `scripts/validate_skill_graph.py`:
+
+```python
+#!/usr/bin/env python3
+"""
+validate_skill_graph.py
+Saudi Legal AI Framework — typed skill relationship graph validator
+
+Checks that every skills/*.md file has a ## Related skills section with
+well-formed, typed edges pointing to existing skills.
+
+Exit codes: 0 = pass (or warnings only), 1 = errors found
+"""
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"
+
+RELATED_SKILLS_HEADING_ALIASES = [
+    "related skills",
+    "مهارات مرتبطة",
+]
+
+ALLOWED_RELATIONSHIP_TYPES = {
+    "escalates_to",
+    "alternative_to",
+    "cross_checks",
+    "depends_on",
+    "specializes",
+    "precedes",
+    "shares_sources_with",
+    "overlaps_with",
+}
+
+
+@dataclass(frozen=True)
+class Edge:
+    target: str        # normalized: "skills/foo.md"
+    relationship: str  # must be in ALLOWED_RELATIONSHIP_TYPES
+    rationale: str     # free text description
+
+
+def _normalize_heading(line: str) -> str:
+    """Strip leading #, section numbers (e.g. 11., §11), and lowercase."""
+    text = re.sub(r"^#+\s*", "", line)
+    text = re.sub(r"^\d+\.\s*", "", text)
+    text = re.sub(r"§\d+\s*", "", text)
+    return text.strip().lower()
+
+
+def _is_related_skills_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in RELATED_SKILLS_HEADING_ALIASES)
+
+
+def _heading_level(line: str) -> int:
+    m = re.match(r"^(#+)", line)
+    return len(m.group(1)) if m else 0
+
+
+def _extract_section(lines: list, heading_predicate) -> str:
+    """Return the text body of the first section matching heading_predicate."""
+    in_section = False
+    section_level = 0
+    body: list = []
+    for line in lines:
+        if not in_section:
+            if line.startswith("#") and heading_predicate(line):
+                in_section = True
+                section_level = _heading_level(line)
+        else:
+            lvl = _heading_level(line)
+            if line.startswith("#") and lvl <= section_level:
+                break
+            body.append(line)
+    return "\n".join(body)
+
+
+def _has_section_heading(lines: list, heading_predicate) -> bool:
+    return any(
+        line.startswith("#") and heading_predicate(line)
+        for line in lines
+    )
+
+
+def _extract_skill_edges(section_text: str) -> list:
+    """
+    Parse 3-line edge blocks from a ## Related skills section body.
+
+    Expected format per edge:
+        * [label](../skills/foo.md)
+          — relationship: escalates_to
+          — rationale text
+
+    Returns only structurally valid blocks. Malformed blocks are reported
+    separately by _find_malformed_entries and validated in run_checks.
+    """
+    lines = [ln.rstrip() for ln in section_text.splitlines()]
+    edges = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith(("* ", "- ")):
+            m = re.search(
+                r'\[([^\]]*)\]\((?:\.\./)?(skills/[\w.-]+\.md)\)',
+                stripped,
+            )
+            if m:
+                target = m.group(2)
+                # Find next non-blank line: — relationship: <type>
+                j = i + 1
+                while j < len(lines) and not lines[j].strip():
+                    j += 1
+                if j < len(lines):
+                    rel_m = re.match(
+                        r'^\s*[—\-]\s*relationship:\s*(\S+)',
+                        lines[j],
+                    )
+                    if rel_m:
+                        relationship = rel_m.group(1)
+                        # Find next non-blank line: — <rationale>
+                        k = j + 1
+                        while k < len(lines) and not lines[k].strip():
+                            k += 1
+                        if k < len(lines):
+                            rat_m = re.match(
+                                r'^\s*[—\-]\s*(.+)',
+                                lines[k],
+                            )
+                            if rat_m:
+                                edges.append(
+                                    Edge(
+                                        target=target,
+                                        relationship=relationship,
+                                        rationale=rat_m.group(1).strip(),
+                                    )
+                                )
+        i += 1
+    return edges
+
+
+def _find_malformed_entries(section_text: str) -> list:
+    """
+    Return bullet lines that are structurally malformed:
+    - Bullet with no link to skills/
+    - Bullet with skills/ link but missing — relationship: line
+    - Bullet with skills/ link and relationship: but missing rationale line
+    """
+    lines = [ln.rstrip() for ln in section_text.splitlines()]
+    malformed = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith(("* ", "- ")):
+            m = re.search(
+                r'\[([^\]]*)\]\((?:\.\./)?(skills/[\w.-]+\.md)\)',
+                stripped,
+            )
+            if not m:
+                malformed.append(stripped)
+                i += 1
+                continue
+            # Has skills link — check for relationship: line
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                j += 1
+            if j >= len(lines) or not re.match(
+                r'^\s*[—\-]\s*relationship:\s*\S+', lines[j]
+            ):
+                malformed.append(stripped)
+                i += 1
+                continue
+            # Check for rationale line
+            k = j + 1
+            while k < len(lines) and not lines[k].strip():
+                k += 1
+            if k >= len(lines) or not re.match(r'^\s*[—\-]\s*.+', lines[k]):
+                malformed.append(stripped)
+        i += 1
+    return malformed
+
+
+def parse_skill(path: Path) -> tuple:
+    """
+    Parse a skill file for its Related skills section.
+
+    Returns (has_section, edges, malformed_entries):
+    - has_section: True if ## Related skills heading found
+    - edges: list of Edge (structurally valid blocks only)
+    - malformed_entries: list of malformed bullet line strings
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    has_section = _has_section_heading(lines, _is_related_skills_heading)
+    if not has_section:
+        return False, [], []
+    section_text = _extract_section(lines, _is_related_skills_heading)
+    return (
+        True,
+        _extract_skill_edges(section_text),
+        _find_malformed_entries(section_text),
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python3 -m pytest tests/test_validate_skill_graph.py -v 2>&1 | tail -10
+```
+
+Expected: `20 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate_skill_graph.py tests/test_validate_skill_graph.py
+git commit -m "feat: add validate_skill_graph.py core parsing functions and unit tests"
+```
+
+---
+
+## Task 2: run_checks, main, graph stats + integration tests
+
+**Files:**
+- Modify: `scripts/validate_skill_graph.py` (append `graph_stats`, `_count_components`, `format_stats`, `run_checks`, `main`)
+- Modify: `tests/test_validate_skill_graph.py` (append 11 integration tests)
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `tests/test_validate_skill_graph.py`:
+
+```python
+# ── graph_stats ──────────────────────────────────────────────────────────────────
+
+def test_graph_stats_basic():
+    graph = {
+        "skills/a.md": [Edge(target="skills/b.md", relationship="escalates_to", rationale="r")],
+        "skills/b.md": [Edge(target="skills/a.md", relationship="alternative_to", rationale="r")],
+    }
+    stats = vsg.graph_stats(graph)
+    assert stats["nodes"] == 2
+    assert stats["edges"] == 2
+    assert stats["orphans"] == []
+    assert stats["components"] == 1
+
+def test_graph_stats_orphan_detected():
+    graph = {
+        "skills/a.md": [Edge(target="skills/b.md", relationship="escalates_to", rationale="r")],
+        "skills/b.md": [],
+        "skills/c.md": [],  # c has no in-edges and no out-edges → orphan
+    }
+    stats = vsg.graph_stats(graph)
+    assert "skills/c.md" in stats["orphans"]
+    assert "skills/b.md" not in stats["orphans"]  # b has in-edge from a
+
+
+# ── run_checks integration ────────────────────────────────────────────────────────
+
+def test_run_checks_passes_all_valid(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    a = skills_dir / "a.md"
+    b = skills_dir / "b.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "a leads to b")])
+    _write_skill_with_edges(b, [("skills/a.md", "alternative_to", "b is alternative to a")])
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text(
+        "## Skill Relationship Graph\n\n| `skills/a.md` |\n| `skills/b.md` |\n",
+        encoding="utf-8",
+    )
+    errors, warnings, stats = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert stats["nodes"] == 2
+    assert stats["edges"] == 2
+
+def test_run_checks_e1_missing_skills_dir(tmp_path):
+    errors, warnings, stats = vsg.run_checks(
+        skills_dir=tmp_path / "nonexistent",
+        cross_ref_map=tmp_path / "map.md",
+    )
+    assert any("not found" in e for e in errors)
+    assert stats == {}
+
+def test_run_checks_e2_broken_path(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "a.md"
+    _write_skill_with_edges(skill, [("skills/missing.md", "escalates_to", "does not exist")])
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("not found" in e for e in errors)
+
+def test_run_checks_e3_invalid_type(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    b = skills_dir / "b.md"
+    _write_skill_no_section(b)
+    a = skills_dir / "a.md"
+    a.write_text(
+        "## Related skills / مهارات مرتبطة\n\n"
+        "* [b.md](../skills/b.md)\n"
+        "  — relationship: invented_type\n"
+        "  — some rationale\n",
+        encoding="utf-8",
+    )
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("unknown relationship type" in e for e in errors)
+
+def test_run_checks_e4_malformed_entry(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _write_skill_malformed_item(skills_dir / "a.md")
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("malformed entry" in e for e in errors)
+
+def test_run_checks_e5_self_reference(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "a.md"
+    _write_skill_with_edges(skill, [("skills/a.md", "depends_on", "itself")])
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("self-reference" in e for e in errors)
+
+def test_run_checks_w1_no_section(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _write_skill_no_section(skills_dir / "a.md")
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert any("no '## Related skills' section" in w for w in warnings)
+
+def test_run_checks_w2_orphan(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    a, b, c = skills_dir / "a.md", skills_dir / "b.md", skills_dir / "c.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "a leads to b")])
+    _write_skill_with_edges(b, [("skills/a.md", "alternative_to", "b to a")])
+    # c has a section but no valid entries → orphan
+    c.write_text(
+        "## Related skills / مهارات مرتبطة\n\n(no entries yet)\n",
+        encoding="utf-8",
+    )
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text(
+        "## Skill Relationship Graph\n"
+        "| `skills/a.md` |\n| `skills/b.md` |\n| `skills/c.md` |\n",
+        encoding="utf-8",
+    )
+    errors, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert any("orphan" in w for w in warnings)
+
+def test_run_checks_w4_map_drift(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    b = skills_dir / "b.md"
+    _write_skill_no_section(b)
+    a = skills_dir / "a.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "rationale")])
+    # cross_ref map exists but has no Skill Relationship Graph section
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Some Other Section\n", encoding="utf-8")
+    _, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("Skill Relationship Graph" in w for w in warnings)
+```
+
+Also add this import near the top of the test file, immediately after `import validate_skill_graph as vsg`:
+
+```python
+from validate_skill_graph import Edge
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+```bash
+python3 -m pytest tests/test_validate_skill_graph.py -v 2>&1 | grep -E "PASSED|FAILED|ERROR" | tail -15
+```
+
+Expected: 20 PASSED (Task 1), 11 FAILED (Task 2 — `graph_stats` and `run_checks` not yet defined)
+
+- [ ] **Step 3: Append the implementation to `scripts/validate_skill_graph.py`**
+
+Append after the `parse_skill` function:
+
+```python
+def _count_components(all_nodes: set, graph: dict) -> int:
+    """Count weakly connected components (treating edges as undirected)."""
+    adjacency: dict = {n: set() for n in all_nodes}
+    for src, edges in graph.items():
+        for e in edges:
+            adjacency.setdefault(src, set()).add(e.target)
+            adjacency.setdefault(e.target, set()).add(src)
+
+    visited: set = set()
+    components = 0
+    for start in all_nodes:
+        if start not in visited:
+            components += 1
+            queue = [start]
+            while queue:
+                node = queue.pop()
+                if node in visited:
+                    continue
+                visited.add(node)
+                queue.extend(adjacency.get(node, set()) - visited)
+    return components
+
+
+def graph_stats(graph: dict) -> dict:
+    """
+    Compute summary statistics for the skill graph.
+
+    graph: dict mapping "skills/source.md" -> list[Edge]
+    Returns a dict with keys: nodes, edges, orphans, most_connected,
+    type_counts, components.
+    """
+    all_nodes: set = set(graph.keys())
+    for edges in graph.values():
+        for e in edges:
+            all_nodes.add(e.target)
+
+    out_degree = {n: len(graph.get(n, [])) for n in all_nodes}
+    in_degree: dict = {n: 0 for n in all_nodes}
+    for edges in graph.values():
+        for e in edges:
+            in_degree[e.target] = in_degree.get(e.target, 0) + 1
+
+    total_degree = {n: out_degree.get(n, 0) + in_degree.get(n, 0) for n in all_nodes}
+    orphans = sorted(n for n in all_nodes if total_degree[n] == 0)
+    most_connected = sorted(all_nodes, key=lambda n: total_degree[n], reverse=True)
+
+    type_counts: dict = {}
+    total_edges = 0
+    for edges in graph.values():
+        for e in edges:
+            type_counts[e.relationship] = type_counts.get(e.relationship, 0) + 1
+            total_edges += 1
+
+    return {
+        "nodes": len(all_nodes),
+        "edges": total_edges,
+        "orphans": orphans,
+        "most_connected": most_connected[:3],
+        "type_counts": type_counts,
+        "components": _count_components(all_nodes, graph) if all_nodes else 0,
+    }
+
+
+def format_stats(stats: dict) -> str:
+    """Format graph statistics for stdout display."""
+    type_str = "  ".join(
+        f"{t}\xd7{c}"
+        for t, c in sorted(stats["type_counts"].items(), key=lambda x: -x[1])
+    ) or "(none)"
+    most_conn = ", ".join(stats["most_connected"]) if stats["most_connected"] else "—"
+    orphan_str = ", ".join(stats["orphans"]) if stats["orphans"] else "none"
+    return "\n".join([
+        "── Skill Graph Summary ───────────────────────────",
+        f"  Nodes (skills):        {stats['nodes']}",
+        f"  Edges (relationships): {stats['edges']}",
+        f"  Orphan skills:         {orphan_str}",
+        f"  Most connected:        {most_conn}",
+        f"  Relationship types:    {type_str}",
+        f"  Connectivity:          {stats['components']} component(s)",
+        "─" * 49,
+    ])
+
+
+def run_checks(
+    skills_dir: Path = SKILLS_DIR,
+    cross_ref_map: Path = CROSS_REF_MAP,
+) -> tuple:
+    """
+    Run all validation checks. Returns (errors, warnings, stats).
+
+    Errors (CI-blocking, exit 1):
+      E1: required skills/ directory missing
+      E2: referenced skill file does not exist on disk
+      E3: invalid relationship type
+      E4: malformed entry structure
+      E5: self-reference
+
+    Warnings (non-blocking, exit 0):
+      W1: skill has no ## Related skills section
+      W2: orphan skill (0 in-edges and 0 out-edges across full graph)
+      W3: asymmetric relationship (informational)
+      W4: cross-reference-map missing Skill Relationship Graph row
+    """
+    errors: list = []
+    warnings: list = []
+
+    if not skills_dir.exists():
+        errors.append(f"ERROR: required directory not found: {skills_dir}")
+        return errors, warnings, {}
+
+    map_text = cross_ref_map.read_text(encoding="utf-8") if cross_ref_map.exists() else ""
+
+    graph: dict = {}
+
+    for skill_file in sorted(skills_dir.glob("*.md")):
+        skill_path = f"skills/{skill_file.name}"
+        has_section, edges, malformed = parse_skill(skill_file)
+
+        # W1: No section
+        if not has_section:
+            warnings.append(
+                f"WARNING: {skill_path} has no '## Related skills' section."
+            )
+            graph[skill_path] = []
+            continue
+
+        graph[skill_path] = []
+
+        # E4: Malformed entries
+        for item in malformed:
+            errors.append(
+                f"ERROR: {skill_path} 'Related skills': malformed entry: {item!r}"
+            )
+
+        for edge in edges:
+            # E5: Self-reference
+            if edge.target == skill_path:
+                errors.append(
+                    f"ERROR: {skill_path} has a self-reference in 'Related skills'."
+                )
+                continue
+
+            # E2: Broken path
+            if not (skills_dir.parent / edge.target).exists():
+                errors.append(
+                    f"ERROR: {skill_path} references {edge.target!r} but file not found."
+                )
+                continue
+
+            # E3: Invalid relationship type
+            if edge.relationship not in ALLOWED_RELATIONSHIP_TYPES:
+                errors.append(
+                    f"ERROR: {skill_path} uses unknown relationship type "
+                    f"{edge.relationship!r} (→ {edge.target})."
+                )
+                continue
+
+            graph[skill_path].append(edge)
+
+        # W4: Map drift
+        row_present = (skill_path in map_text) and ("Skill Relationship Graph" in map_text)
+        if not row_present:
+            warnings.append(
+                f"WARNING: cross-reference-map.md 'Skill Relationship Graph' "
+                f"may be missing row for {skill_path}."
+            )
+
+    # Compute stats over full graph
+    stats = graph_stats(graph)
+
+    # W2: Orphan skills
+    for orphan in stats["orphans"]:
+        warnings.append(
+            f"WARNING: {orphan} appears to be an orphan (0 in-edges and 0 out-edges)."
+        )
+
+    # W3: Asymmetric relationships (informational)
+    for src, src_edges in graph.items():
+        for e in src_edges:
+            target_edges = graph.get(e.target, [])
+            reverse_exists = any(te.target == src for te in target_edges)
+            if not reverse_exists:
+                warnings.append(
+                    f"WARNING: asymmetric — {src} → {e.target} "
+                    f"({e.relationship}) has no reverse edge."
+                )
+
+    return errors, warnings, stats
+
+
+def main() -> None:
+    errors, warnings, stats = run_checks()
+
+    if stats:
+        print(format_stats(stats))
+
+    for w in warnings:
+        print(w)
+    for e in errors:
+        print(e)
+
+    if not errors and not warnings:
+        print("✓ All skill graph checks passed.")
+    elif not errors:
+        print("✓ No errors. See warnings above.")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+python3 -m pytest tests/test_validate_skill_graph.py -v 2>&1 | tail -15
+```
+
+Expected: `31 passed`
+
+- [ ] **Step 5: Smoke-test the validator against the real repo**
+
+```bash
+python3 scripts/validate_skill_graph.py
+```
+
+Expected: W1 warnings for all 7 skill files (no `## Related skills` yet), stats block showing 7 orphan nodes, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/validate_skill_graph.py tests/test_validate_skill_graph.py
+git commit -m "feat: add run_checks, graph_stats, and integration tests for validate_skill_graph"
+```
+
+---
+
+## Task 3: Add ## Related skills sections to all 7 skill files
+
+**Files:** Modify all 7 `skills/*.md` files.
+
+The `## Related skills` section is inserted **before** the existing `## Related examples` section in each file. The match pattern for every file is the `---` separator line immediately preceding `## Related examples`.
+
+After this task, running `python3 scripts/validate_skill_graph.py` should produce 0 errors. W3 (asymmetric) warnings are expected and non-blocking.
+
+- [ ] **Step 1: Edit `skills/contract-review.md`**
+
+Find and replace (the `---` immediately before `## Related examples`):
+
+old_string:
+```
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+new_string:
+```
+---
+
+## Related skills / مهارات مرتبطة
+
+* [commercial-dispute.md](../skills/commercial-dispute.md)
+  — relationship: escalates_to
+  — unresolved contract breach or contested clause may require Commercial Court proceedings
+
+* [arbitration.md](../skills/arbitration.md)
+  — relationship: escalates_to
+  — an arbitration clause in the contract activates this path instead of court litigation
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: precedes
+  — review identifies gaps and red flags; legal-drafting is then used to address them
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: cross_checks
+  — contracts containing PDPL clauses, Nitaqat obligations, or WPS terms need compliance verification
+
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+- [ ] **Step 2: Edit `skills/commercial-dispute.md`**
+
+old_string:
+```
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+new_string:
+```
+---
+
+## Related skills / مهارات مرتبطة
+
+* [arbitration.md](../skills/arbitration.md)
+  — relationship: alternative_to
+  — arbitration replaces court litigation when a valid arbitration clause exists or parties agree
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: precedes
+  — formal demand notices must be drafted before court filing
+
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+- [ ] **Step 3: Edit `skills/arbitration.md`**
+
+old_string:
+```
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+new_string:
+```
+---
+
+## Related skills / مهارات مرتبطة
+
+* [commercial-dispute.md](../skills/commercial-dispute.md)
+  — relationship: alternative_to
+  — Commercial Court litigation is the fallback when arbitration is excluded, waived, or fails
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: depends_on
+  — arbitration requests, submissions, and award enforcement filings require legal drafting
+
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+- [ ] **Step 4: Edit `skills/compliance-check.md`**
+
+old_string:
+```
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+new_string:
+```
+---
+
+## Related skills / مهارات مرتبطة
+
+* [labor-law-analysis.md](../skills/labor-law-analysis.md)
+  — relationship: cross_checks
+  — Nitaqat (Saudization), WPS, and GOSI compliance are labor law sub-domains that require cross-verification
+
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+- [ ] **Step 5: Edit `skills/labor-law-analysis.md`**
+
+old_string:
+```
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+new_string:
+```
+---
+
+## Related skills / مهارات مرتبطة
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: cross_checks
+  — employment compliance dimensions (PDPL over HR data, Saudization quotas) cross both domains
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: depends_on
+  — employment contracts are analysed using the contract-review methodology for clause-level risk
+
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+- [ ] **Step 6: Edit `skills/legal-drafting.md`**
+
+old_string:
+```
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+new_string:
+```
+---
+
+## Related skills / مهارات مرتبطة
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: depends_on
+  — quality criteria for drafted documents are grounded in contract-review red flags and mandatory clause checklists
+
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+- [ ] **Step 7: Edit `skills/real-estate-contracts.md`**
+
+old_string:
+```
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+new_string:
+```
+---
+
+## Related skills / مهارات مرتبطة
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: specializes
+  — real estate contracts are a domain-scoped application of the general contract review methodology
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: depends_on
+  — Ejar registration, municipal approvals, and REGA requirements are compliance obligations
+
+---
+
+## Related examples / أمثلة مرتبطة
+```
+
+- [ ] **Step 8: Run the validator to confirm 0 errors**
+
+```bash
+python3 scripts/validate_skill_graph.py
+```
+
+Expected output (W3 asymmetric warnings are expected on 8 one-directional edges, exit 0):
+
+```
+── Skill Graph Summary ─────────────────────────────────────
+  Nodes (skills):        7
+  Edges (relationships): 14
+  Orphan skills:         none
+  Most connected:        skills/contract-review.md, skills/legal-drafting.md, skills/arbitration.md
+  Relationship types:    escalates_to×4  cross_checks×4  depends_on×4  alternative_to×2  precedes×2  specializes×1
+  Connectivity:          1 component(s)
+─────────────────────────────────────────────────────────────
+WARNING: asymmetric — skills/contract-review.md → skills/commercial-dispute.md (escalates_to) has no reverse edge.
+[... ~8 similar W3 lines ...]
+✓ No errors. See warnings above.
+```
+
+Exit code: 0
+
+- [ ] **Step 9: Run full test suite to confirm no regressions**
+
+```bash
+python3 -m pytest tests/ -v 2>&1 | tail -5
+```
+
+Expected: all tests pass (count will be prior 118 + 31 new = 149 total)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add skills/arbitration.md skills/commercial-dispute.md skills/compliance-check.md \
+        skills/contract-review.md skills/labor-law-analysis.md skills/legal-drafting.md \
+        skills/real-estate-contracts.md
+git commit -m "docs: add Related skills sections to all 7 skill files (14-edge typed graph)"
+```
+
+---
+
+## Task 4: Update docs/cross-reference-map.md
+
+**Files:** Modify `docs/cross-reference-map.md`
+
+Insert the `## Skill Relationship Graph` section between `## Skill → Example Coverage` and `## 4. Sources ← → Regulations`.
+
+- [ ] **Step 1: Edit `docs/cross-reference-map.md`**
+
+Locate the `---` line at line 115 (between `## Skill → Example Coverage` and `## 4. Sources ← → Regulations`) and insert the new section before it.
+
+old_string:
+```
+**Coverage rules:** 0 examples → Missing | 1 example → Partial | 2+ examples → Strong
+
+---
+
+## 4. Sources ← → Regulations / المصادر ← → الأنظمة
+```
+
+new_string:
+```
+**Coverage rules:** 0 examples → Missing | 1 example → Partial | 2+ examples → Strong
+
+---
+
+## Skill Relationship Graph
+
+> هذا الجدول مُولَّد من `## Related skills` في كل ملف `skills/*.md`.
+> يُشغَّل `scripts/validate_skill_graph.py` في كل push للتحقق منه.
+> This table is derived from `## Related skills` in each `skills/*.md` file.
+> `scripts/validate_skill_graph.py` runs on every push to verify it.
+
+| Skill | Related Skills | Relationship Types | Graph Degree | Connectivity Status |
+|---|---|---|---|---|
+| `skills/arbitration.md` | `skills/commercial-dispute.md` · `skills/legal-drafting.md` | `alternative_to` · `depends_on` | 4 (2 out, 2 in) | Connected |
+| `skills/commercial-dispute.md` | `skills/arbitration.md` · `skills/legal-drafting.md` | `alternative_to` · `precedes` | 4 (2 out, 2 in) | Connected |
+| `skills/compliance-check.md` | `skills/labor-law-analysis.md` | `cross_checks` | 4 (1 out, 3 in) | Connected |
+| `skills/contract-review.md` | `skills/commercial-dispute.md` · `skills/arbitration.md` · `skills/legal-drafting.md` · `skills/compliance-check.md` | `escalates_to` · `precedes` · `cross_checks` | 7 (4 out, 3 in) | Connected |
+| `skills/labor-law-analysis.md` | `skills/compliance-check.md` · `skills/contract-review.md` | `cross_checks` · `depends_on` | 3 (2 out, 1 in) | Connected |
+| `skills/legal-drafting.md` | `skills/contract-review.md` | `depends_on` | 4 (1 out, 3 in) | Connected |
+| `skills/real-estate-contracts.md` | `skills/contract-review.md` · `skills/compliance-check.md` | `specializes` · `depends_on` | 2 (2 out, 0 in) | Connected |
+
+**Allowed relationship types:** `escalates_to` · `alternative_to` · `cross_checks` · `depends_on` · `specializes` · `precedes` · `shares_sources_with` · `overlaps_with`
+
+---
+
+## 4. Sources ← → Regulations / المصادر ← → الأنظمة
+```
+
+- [ ] **Step 2: Run the validator to confirm W4 warnings are now gone**
+
+```bash
+python3 scripts/validate_skill_graph.py 2>&1 | grep "W4\|Skill Relationship Graph"
+```
+
+Expected: no output (all 7 rows present in map).
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+python3 -m pytest tests/ -v 2>&1 | tail -5
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/cross-reference-map.md
+git commit -m "docs: add Skill Relationship Graph section to cross-reference-map.md"
+```
+
+---
+
+## Task 5: Wire validator into CI
+
+**Files:** Modify `.github/workflows/validate-datasets.yml`
+
+The new step goes after `Validate example coverage` and before `Validate main dataset`.
+
+- [ ] **Step 1: Edit `.github/workflows/validate-datasets.yml`**
+
+old_string:
+```
+      - name: Validate example coverage
+        run: python3 scripts/validate_example_coverage.py
+
+      - name: Validate main dataset
+```
+
+new_string:
+```
+      - name: Validate example coverage
+        run: python3 scripts/validate_example_coverage.py
+
+      - name: Validate skill graph
+        run: python3 scripts/validate_skill_graph.py
+
+      - name: Validate main dataset
+```
+
+- [ ] **Step 2: Run full test suite one final time**
+
+```bash
+python3 -m pytest tests/ -v 2>&1 | tail -5
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run all three validators in sequence (mirrors CI)**
+
+```bash
+python3 scripts/validate_cross_refs.py && \
+python3 scripts/validate_example_coverage.py && \
+python3 scripts/validate_skill_graph.py
+```
+
+Expected: all three exit 0. The skill graph validator prints the summary block followed by W3 asymmetric warnings; exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/validate-datasets.yml
+git commit -m "ci: add validate_skill_graph.py step after validate_example_coverage.py"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ `## Related skills / مهارات مرتبطة` section added to every skill (Task 3)
+- ✅ 3-line entry format (path, typed relationship, rationale) defined and parsed (Task 1)
+- ✅ All 8 relationship types implemented in `ALLOWED_RELATIONSHIP_TYPES` (Task 1)
+- ✅ Validator parses sections, validates paths, validates types, detects malformed entries, self-refs, orphans (Task 2)
+- ✅ Graph summary stats (nodes, edges, orphans, most connected, type distribution, components) (Task 2)
+- ✅ Tests: unit + integration, 31 tests (Tasks 1–2)
+- ✅ `## Skill Relationship Graph` table in cross-reference-map.md (Task 4)
+- ✅ CI wiring after `validate_example_coverage.py` (Task 5)
+- ✅ No export stubs — JSON/DOT/Mermaid deferred to follow-up PR
+
+**Type consistency check:** `Edge.target`, `Edge.relationship`, `Edge.rationale` used consistently across `_extract_skill_edges`, `parse_skill`, `run_checks`, `graph_stats`. `graph` dict type `dict[str, list[Edge]]` consistent throughout.
+
+**Future visualization note:** The `graph_stats` return value is a plain `dict` containing an adjacency list and stats. A follow-up PR can add `--export-json`, `--export-dot`, or `--export-mermaid` flags to `main()` by serializing this dict — no changes to the core validator needed.

--- a/docs/superpowers/specs/2026-05-25-reverse-discovery-seam-design.md
+++ b/docs/superpowers/specs/2026-05-25-reverse-discovery-seam-design.md
@@ -1,0 +1,198 @@
+# Reverse-Discovery Seam — Design Spec
+
+**Date:** 2026-05-25
+**Status:** Awaiting implementation
+**Scope:** sources→skills only (Phase 1 of bidirectional cascade)
+
+---
+
+## Problem
+
+The framework's cascade is unidirectional: prompts → skills → sources. A user or AI starting from a `sources/` file has no path to the skills that implement it or the examples that demonstrate it. Coverage gaps are invisible without manual grep. The existing `docs/cross-reference-map.md` captures the forward direction (skills→sources in §1) but has no reverse.
+
+---
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Where does the reverse seam live? | Both: `cross-reference-map.md` as authoritative index + "See also" in each `sources/` file |
+| Scope | sources→skills only (this spec); skills→examples and skills→prompts in follow-on |
+| Maintenance | Script-enforced CI validation |
+| "See also" format | Skill name + link + which section of that skill cites this source |
+
+---
+
+## Invariant
+
+> **If a `sources/` file is cited in any `skills/*.md` §11 (Relevant Regulations), it must have a `## See also / انظر أيضًا` section.**
+
+Missing section = CI failure. This is checked before link correctness.
+
+---
+
+## Change 1 — `docs/cross-reference-map.md`
+
+Add **Section 1b** immediately after the existing Section 1 (Skills ↔ Sources):
+
+```markdown
+## 1b. Sources → Skills — Reverse Index / المصادر → المهارات (فهرس عكسي)
+
+> هذا الجدول مصدر الحقيقة للـ CI. أي تغيير في §11 لأي skill يستلزم تحديثه.
+> This table is the CI source of truth. Any change to a skill's §11 requires updating it.
+
+| Source File | Cited by Skill | Section | طبيعة الاستخدام |
+|---|---|---|---|
+| `sources/civil-transactions-law.md` | `skills/contract-review.md` | §11 | المصدر الرئيسي للعقود المدنية |
+| `sources/civil-transactions-law.md` | `skills/legal-drafting.md` | §11 | مرجع مبادئ الصياغة |
+| `sources/labor-law.md` | `skills/contract-review.md` | §11 | نطاق العقود الوظيفية |
+| `sources/labor-law.md` | `skills/labor-law-analysis.md` | §11 | النظام الأساسي للمهارة |
+| `sources/labor-law.md` | `skills/compliance-check.md` | §11 | نطاقات / Saudization |
+| `sources/companies-law.md` | `skills/contract-review.md` | §11 | الشركات كطرف متعاقد |
+| `sources/companies-law.md` | `skills/compliance-check.md` | §11 | متطلبات الحوكمة |
+| `sources/pdpl.md` | `skills/contract-review.md` | §11 | بنود البيانات الشخصية |
+| `sources/pdpl.md` | `skills/compliance-check.md` | §11 | النظام الأساسي للامتثال |
+| `sources/commercial-courts.md` | `skills/contract-review.md` | §11 | اختصاص المحكمة |
+| `sources/commercial-courts.md` | `skills/commercial-dispute.md` | §11 | النظام الأساسي للمهارة |
+| `sources/saudi-laws.md` | `skills/commercial-dispute.md` | §11 | مرجع عام للنزاعات |
+| `sources/saudi-laws.md` | `skills/legal-drafting.md` | §11 | مرجع عام للصياغة |
+```
+
+> **Note:** These rows are illustrative based on current cross-reference-map.md §1 data. The implementation step must audit each `skills/*.md` §11 directly to confirm and complete the table before adding it.
+
+Also update the **maintenance rule** for "When Adding a New Source" to include:
+
+```
+✅ أضف "See also" في ملف الـ source الجديد إذا أشار إليه أي skill في §11
+```
+
+And add a new maintenance rule **"When Editing a Skill's §11"**:
+
+```
+✅ حدّث Section 1b في cross-reference-map.md
+✅ حدّث "See also" في كل sources/ file أُضيف أو حُذف من §11
+✅ شغّل: python scripts/validate_cross_refs.py
+```
+
+---
+
+## Change 2 — `## See also` in each `sources/` file
+
+Add this section at the **end** of each source file that is cited by at least one skill. Five files need it today:
+
+- `sources/civil-transactions-law.md`
+- `sources/labor-law.md`
+- `sources/companies-law.md`
+- `sources/pdpl.md`
+- `sources/commercial-courts.md`
+- `sources/saudi-laws.md`
+
+**Section format** (bilingual, consistent across all files):
+
+```markdown
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/contract-review.md](../skills/contract-review.md) | §11 الأنظمة المرتبطة | المصدر الرئيسي للعقود المدنية |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة المرتبطة | مرجع مبادئ الصياغة |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md` — Section 1b](../docs/cross-reference-map.md)
+```
+
+Rules:
+- The section is added **only** if the source is cited by at least one skill's §11.
+- The link text for each row uses the relative path from `sources/` to `skills/` (`../skills/`).
+- The footer link always points to `cross-reference-map.md` Section 1b.
+
+---
+
+## Change 3 — `scripts/validate_cross_refs.py`
+
+New script. Runs standalone; no new dependencies beyond the Python stdlib already used by `validate_dataset.py`.
+
+### What it parses
+
+**From each `skills/*.md`:**
+Extract the §11 section (heading contains "Relevant Regulations" or "الأنظمة المرتبطة"). Within that section, collect every `sources/` path mentioned (via regex on backtick-quoted paths or markdown links).
+
+**From each `sources/*.md`:**
+Detect whether a `## See also` section exists. If it does, extract every `skills/` path listed in it.
+
+### Checks (in order)
+
+**Check 1 — Missing "See also" (invariant)**
+For every `(source_file, skill_file)` pair found in skills §11: if `source_file` has no `## See also` section → **FAIL**.
+
+```
+ERROR: sources/labor-law.md is cited by skills/labor-law-analysis.md §11
+       but has no "## See also" section.
+```
+
+**Check 2 — Missing reverse link**
+For every `(source_file, skill_file)` pair found in skills §11: if `source_file`'s "See also" does not list `skill_file` → **FAIL**.
+
+```
+ERROR: sources/labor-law.md "See also" is missing skills/compliance-check.md
+       (cited in skills/compliance-check.md §11).
+```
+
+**Check 3 — Phantom reference**
+For every `skill_file` listed in a `source_file`'s "See also": if that skill's §11 does not cite the source → **FAIL**.
+
+```
+ERROR: sources/labor-law.md "See also" lists skills/legal-drafting.md
+       but skills/legal-drafting.md §11 does not cite sources/labor-law.md.
+```
+
+**Check 4 — Cross-reference-map.md sync**
+For every `(source_file, skill_file)` pair confirmed by checks 1–3: if Section 1b of `cross-reference-map.md` does not contain a row for that pair → **WARN** (not FAIL — the map is documentation, not enforcement).
+
+```
+WARNING: cross-reference-map.md Section 1b is missing row:
+         sources/pdpl.md → skills/compliance-check.md
+```
+
+### Exit codes
+
+- `0` — all checks pass
+- `1` — any FAIL (Check 1, 2, or 3)
+- Warnings (Check 4) print but do not affect exit code
+
+### Integration
+
+Add to `.github/workflows/validate-datasets.yml` as a second step in the existing validation job, after `validate_dataset.py`:
+
+```yaml
+- name: Validate cross-references
+  run: python scripts/validate_cross_refs.py
+```
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `docs/cross-reference-map.md` | Add Section 1b reverse index table + two maintenance rules |
+| `sources/civil-transactions-law.md` | Add `## See also` |
+| `sources/labor-law.md` | Add `## See also` |
+| `sources/companies-law.md` | Add `## See also` |
+| `sources/pdpl.md` | Add `## See also` |
+| `sources/commercial-courts.md` | Add `## See also` |
+| `sources/saudi-laws.md` | Add `## See also` |
+| `scripts/validate_cross_refs.py` | New file |
+| `.github/workflows/validate-datasets.yml` | Add validation step |
+
+---
+
+## Out of scope (follow-on)
+
+- skills→examples reverse links (Candidate 3 in architecture report)
+- skills→prompts seam declaration (Candidate 2)
+- skills cross-reference seams (Candidate 4)
+- Completing `real-estate-contracts.md §11` (Candidate 5 — its incomplete §11 will produce Check 4 warnings but not block CI, since Check 4 is WARN not FAIL)

--- a/docs/superpowers/specs/2026-05-25-reverse-discovery-seam-design.md
+++ b/docs/superpowers/specs/2026-05-25-reverse-discovery-seam-design.md
@@ -118,35 +118,46 @@ New script. Runs standalone; no new dependencies beyond the Python stdlib alread
 ### What it parses
 
 **From each `skills/*.md`:**
-Extract the §11 section (heading contains "Relevant Regulations" or "الأنظمة المرتبطة"). Within that section, collect every `sources/` path mentioned (via regex on backtick-quoted paths or markdown links).
+Locate the "regulations" section using flexible heading detection — match any heading that contains one of the recognized aliases (case-insensitive, ignoring leading `##`, section numbers like `§11`, and surrounding whitespace):
+
+```python
+REGULATIONS_HEADING_ALIASES = [
+    "relevant regulations",
+    "الأنظمة المرتبطة",
+    # add future aliases here — script must not hardcode §11
+]
+```
+
+The section ends at the next same-level heading. Within the matched section, collect every `sources/` path mentioned via backtick-quoted paths (`` `sources/foo.md` ``) or markdown links (`[text](../sources/foo.md)`).
 
 **From each `sources/*.md`:**
-Detect whether a `## See also` section exists. If it does, extract every `skills/` path listed in it.
+Detect whether a `## See also` section (or `## See also / انظر أيضًا`) exists. If it does, extract every `skills/` path listed in it using the same dual-format regex.
 
 ### Checks (in order)
 
 **Check 1 — Missing "See also" (invariant)**
-For every `(source_file, skill_file)` pair found in skills §11: if `source_file` has no `## See also` section → **FAIL**.
+For every `(source_file, skill_file)` pair found in the regulations section: if `source_file` has no `## See also` section → **FAIL**.
 
 ```
-ERROR: sources/labor-law.md is cited by skills/labor-law-analysis.md §11
-       but has no "## See also" section.
+ERROR: sources/labor-law.md is cited by skills/labor-law-analysis.md
+       (regulations section) but has no "## See also" section.
 ```
 
 **Check 2 — Missing reverse link**
-For every `(source_file, skill_file)` pair found in skills §11: if `source_file`'s "See also" does not list `skill_file` → **FAIL**.
+For every `(source_file, skill_file)` pair found in the regulations section: if `source_file`'s "See also" does not list `skill_file` → **FAIL**.
 
 ```
 ERROR: sources/labor-law.md "See also" is missing skills/compliance-check.md
-       (cited in skills/compliance-check.md §11).
+       (cited in its regulations section).
 ```
 
 **Check 3 — Phantom reference**
-For every `skill_file` listed in a `source_file`'s "See also": if that skill's §11 does not cite the source → **FAIL**.
+For every `skill_file` listed in a `source_file`'s "See also": if that skill's regulations section does not cite the source → **FAIL**.
 
 ```
 ERROR: sources/labor-law.md "See also" lists skills/legal-drafting.md
-       but skills/legal-drafting.md §11 does not cite sources/labor-law.md.
+       but skills/legal-drafting.md regulations section does not cite
+       sources/labor-law.md.
 ```
 
 **Check 4 — Cross-reference-map.md sync**
@@ -156,6 +167,24 @@ For every `(source_file, skill_file)` pair confirmed by checks 1–3: if Section
 WARNING: cross-reference-map.md Section 1b is missing row:
          sources/pdpl.md → skills/compliance-check.md
 ```
+
+### `--fix` mode (future)
+
+The script accepts `--fix` as a future flag:
+
+```
+python scripts/validate_cross_refs.py --fix
+```
+
+Behaviour when `--fix` is passed:
+- For every Check 1 failure: create a `## See also / انظر أيضًا` section in the source file with the correct rows.
+- For every Check 2 failure: append the missing skill row to the existing "See also" section.
+- For every Check 4 warning: append the missing row to Section 1b of `cross-reference-map.md`.
+- Check 3 (phantom references) is never auto-fixed — removal requires human judgment.
+- Prints a summary of every file modified.
+- Exits 0 if all fixes applied cleanly; exits 1 if any phantom references remain.
+
+`--fix` is not implemented in the initial version. The flag is reserved so future callers don't break when it is added.
 
 ### Exit codes
 

--- a/prompts/draft-notice.md
+++ b/prompts/draft-notice.md
@@ -6,7 +6,7 @@
 
 ---
 
-## ⚠️ تحذير / Warning
+## ⚠️ تحذير مُدمج (يجب تضمينه في المخرجات) / Embedded Warning
 
 > **تحذير:** هذا تحليل أولي بمساعدة الذكاء الاصطناعي ولا يعد استشارة قانونية. يجب مراجعة مختص قانوني مرخص في المملكة العربية السعودية قبل اتخاذ أي إجراء.
 >
@@ -25,6 +25,9 @@
 ---
 
 ## القالب العام / General Template
+
+> **مرجع هيكل التقرير:** القالب أدناه يُنتج مخرجًا بـ 4 أقسام موحَّدة — المصدر الرسمي لهذا الهيكل هو `skills/legal-drafting.md §8`.
+> **Report format reference:** The template below produces a 4-section standardised output — the authoritative definition lives in `skills/legal-drafting.md §8`.
 
 ```
 أنت متخصص في الصياغة القانونية السعودية. أنشئ إشعارًا قانونيًا رسميًا وفق المعايير الآتية:

--- a/prompts/risk-analysis.md
+++ b/prompts/risk-analysis.md
@@ -6,7 +6,7 @@
 
 ---
 
-## ⚠️ تحذير / Warning
+## ⚠️ تحذير مُدمج (يجب تضمينه في المخرجات) / Embedded Warning
 
 > **تحذير:** هذا تحليل أولي بمساعدة الذكاء الاصطناعي ولا يعد استشارة قانونية. يجب مراجعة مختص قانوني مرخص في المملكة العربية السعودية قبل اتخاذ أي إجراء.
 >
@@ -15,6 +15,9 @@
 ---
 
 ## القالب الأساسي / Base Template
+
+> **مرجع هيكل التقرير:** القالب أدناه يُنتج مخرجًا بـ 9 أقسام موحَّدة — المصدر الرسمي لهذا الهيكل هو `skills/compliance-check.md §8`.
+> **Report format reference:** The template below produces a 9-section standardised output — the authoritative definition lives in `skills/compliance-check.md §8`.
 
 ```
 أنت مستشار قانوني متخصص في القانون السعودي مهمتك تحليل المخاطر القانونية.

--- a/scripts/validate_cross_refs.py
+++ b/scripts/validate_cross_refs.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+validate_cross_refs.py
+Saudi Legal AI Framework — reverse-discovery seam validator
+
+Checks that every sources/ file cited in a skill's regulations section
+has a matching ## See also section listing that skill.
+
+Usage:
+    python scripts/validate_cross_refs.py          # validate
+    python scripts/validate_cross_refs.py --fix    # auto-fix (not yet implemented)
+
+Exit codes: 0 = pass, 1 = errors found
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+SOURCES_DIR = REPO_ROOT / "sources"
+CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"
+
+# Heading aliases for the regulations section — add future aliases here.
+# Matching is case-insensitive and strips leading #, digits, §, and whitespace.
+REGULATIONS_HEADING_ALIASES = [
+    "relevant regulations",
+    "الأنظمة المرتبطة",
+    "الأنظمة ذات الصلة",
+]
+
+# Heading aliases for the See also section.
+SEE_ALSO_HEADING_ALIASES = [
+    "see also",
+    "انظر أيضًا",
+]
+
+# Sources excluded from validation — meta-documents that are not substantive
+# legal sources (cited only as format/citation references).
+EXCLUDED_SOURCES = {
+    "sources/regulation-index.md",
+}
+
+
+def _normalize_heading(line: str) -> str:
+    """Strip leading #, section numbers (11., §11), and lowercase."""
+    text = re.sub(r"^#+\s*", "", line)
+    text = re.sub(r"^\d+\.\s*", "", text)
+    text = re.sub(r"§\d+\s*", "", text)
+    return text.strip().lower()
+
+
+def _is_regulations_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in REGULATIONS_HEADING_ALIASES)
+
+
+def _is_see_also_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in SEE_ALSO_HEADING_ALIASES)
+
+
+def _heading_level(line: str) -> int:
+    m = re.match(r"^(#+)", line)
+    return len(m.group(1)) if m else 0
+
+
+def _extract_section(lines: list, heading_predicate) -> str:
+    """Return the text body of the first section matching heading_predicate."""
+    in_section = False
+    section_level = 0
+    body: list = []
+    for line in lines:
+        if not in_section:
+            if line.startswith("#") and heading_predicate(line):
+                in_section = True
+                section_level = _heading_level(line)
+        else:
+            lvl = _heading_level(line)
+            if line.startswith("#") and lvl <= section_level:
+                break
+            body.append(line)
+    return "\n".join(body)
+
+
+def _extract_source_paths(text: str) -> set:
+    """Return all sources/*.md paths mentioned in text, excluding EXCLUDED_SOURCES."""
+    found = set(re.findall(r"sources/[\w-]+\.md", text))
+    return found - EXCLUDED_SOURCES
+
+
+def _extract_skill_paths(text: str) -> set:
+    """Return all skills/*.md paths mentioned in text."""
+    return set(re.findall(r"skills/[\w-]+\.md", text))
+
+
+def parse_skill(path: Path) -> set:
+    """Return sources/*.md paths cited in this skill's regulations section."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    section_text = _extract_section(lines, _is_regulations_heading)
+    return _extract_source_paths(section_text)
+
+
+def parse_source(path: Path) -> tuple:
+    """Return (has_see_also, set of skills/*.md paths listed in See also)."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    section_text = _extract_section(lines, _is_see_also_heading)
+    has_see_also = bool(section_text.strip())
+    return has_see_also, _extract_skill_paths(section_text)
+
+
+def run_checks(
+    skills_dir: Path = SKILLS_DIR,
+    sources_dir: Path = SOURCES_DIR,
+    cross_ref_map: Path = CROSS_REF_MAP,
+) -> tuple:
+    """
+    Run all four checks. Returns (errors, warnings).
+    errors   → Check 1 / 2 / 3 (CI-blocking)
+    warnings → Check 4 (documentation drift, non-blocking)
+    """
+    errors: list = []
+    warnings: list = []
+
+    # Build (source_path → set of citing skill_paths) from all skills
+    skill_citations: dict = {}
+    for skill_file in sorted(skills_dir.glob("*.md")):
+        cited = parse_skill(skill_file)
+        skill_path = f"skills/{skill_file.name}"
+        for source_path in cited:
+            skill_citations.setdefault(source_path, set()).add(skill_path)
+
+    # Parse each cited source's See also
+    source_see_also: dict = {}
+    for source_path_str, citing_skills in skill_citations.items():
+        source_file = sources_dir / Path(source_path_str).name
+        if not source_file.exists():
+            errors.append(
+                f"ERROR: {source_path_str} is referenced in skills but file not found."
+            )
+            continue
+
+        has_see_also, listed_skills = parse_source(source_file)
+        source_see_also[source_path_str] = listed_skills
+
+        # Check 1: cited source has no See also section
+        if not has_see_also:
+            for skill in sorted(citing_skills):
+                errors.append(
+                    f"ERROR: {source_path_str} is cited by {skill} "
+                    f"(regulations section) but has no '## See also' section."
+                )
+            continue
+
+        # Check 2: See also is missing a citing skill
+        for skill in sorted(citing_skills):
+            if skill not in listed_skills:
+                errors.append(
+                    f"ERROR: {source_path_str} 'See also' is missing {skill} "
+                    f"(cited in its regulations section)."
+                )
+
+    # Check 3: phantom references (See also lists a skill that doesn't cite it).
+    # Scan ALL source files so we catch phantom entries in sources never cited by any skill.
+    all_source_see_also: dict = {}
+    for source_file in sorted(sources_dir.glob("*.md")):
+        source_path_str = f"sources/{source_file.name}"
+        if source_path_str in EXCLUDED_SOURCES:
+            continue
+        _has, listed = parse_source(source_file)
+        if listed:
+            all_source_see_also[source_path_str] = listed
+
+    for source_path_str, listed_skills in all_source_see_also.items():
+        citing_skills = skill_citations.get(source_path_str, set())
+        for skill in sorted(listed_skills):
+            if skill not in citing_skills:
+                errors.append(
+                    f"ERROR: {source_path_str} 'See also' lists {skill} "
+                    f"but {skill} regulations section does not cite {source_path_str}."
+                )
+
+    # Check 4: cross-reference-map.md Section 1b sync (warn only)
+    map_text = cross_ref_map.read_text(encoding="utf-8") if cross_ref_map.exists() else ""
+    for source_path_str, citing_skills in skill_citations.items():
+        for skill in sorted(citing_skills):
+            if source_path_str not in map_text or skill not in map_text:
+                warnings.append(
+                    f"WARNING: cross-reference-map.md Section 1b may be missing row: "
+                    f"{source_path_str} → {skill}"
+                )
+
+    return errors, warnings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate reverse-discovery seam in sources/ and skills/."
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix missing See also sections (not yet implemented).",
+    )
+    args = parser.parse_args()
+
+    if args.fix:
+        print("--fix mode is not yet implemented.")
+        sys.exit(0)
+
+    errors, warnings = run_checks()
+
+    for w in warnings:
+        print(w)
+    for e in errors:
+        print(e)
+
+    if not errors and not warnings:
+        print("✓ All cross-reference checks passed.")
+    elif not errors:
+        print("✓ No errors. See warnings above.")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_cross_refs.py
+++ b/scripts/validate_cross_refs.py
@@ -120,9 +120,21 @@ def run_checks(
     Run all four checks. Returns (errors, warnings).
     errors   → Check 1 / 2 / 3 (CI-blocking)
     warnings → Check 4 (documentation drift, non-blocking)
+
+    Check 3 scans all sources/*.md files — not just those cited by skills —
+    so a source file that lists a skill in its See also section without being
+    cited by that skill's regulations section will produce an error even if
+    no skill currently cites the source.
     """
     errors: list = []
     warnings: list = []
+
+    # Guard: required directories must exist before any glob
+    for d in (skills_dir, sources_dir):
+        if not d.exists():
+            errors.append(f"ERROR: required directory not found: {d}")
+    if errors:
+        return errors, warnings
 
     # Build (source_path → set of citing skill_paths) from all skills
     skill_citations: dict = {}
@@ -137,8 +149,9 @@ def run_checks(
     for source_path_str, citing_skills in skill_citations.items():
         source_file = sources_dir / Path(source_path_str).name
         if not source_file.exists():
+            citing = ", ".join(sorted(citing_skills))
             errors.append(
-                f"ERROR: {source_path_str} is referenced in skills but file not found."
+                f"ERROR: {source_path_str} is referenced in {citing} but file not found."
             )
             continue
 
@@ -184,9 +197,11 @@ def run_checks(
 
     # Check 4: cross-reference-map.md Section 1b sync (warn only)
     map_text = cross_ref_map.read_text(encoding="utf-8") if cross_ref_map.exists() else ""
+    map_lines = map_text.splitlines() if cross_ref_map.exists() else []
     for source_path_str, citing_skills in skill_citations.items():
         for skill in sorted(citing_skills):
-            if source_path_str not in map_text or skill not in map_text:
+            pair_found = any(source_path_str in line and skill in line for line in map_lines)
+            if not pair_found:
                 warnings.append(
                     f"WARNING: cross-reference-map.md Section 1b may be missing row: "
                     f"{source_path_str} → {skill}"

--- a/scripts/validate_example_coverage.py
+++ b/scripts/validate_example_coverage.py
@@ -139,3 +139,106 @@ def coverage_status(count: int) -> str:
     if count == COVERAGE_PARTIAL:
         return "Partial"
     return "Missing"
+
+
+def run_checks(
+    skills_dir: Path = SKILLS_DIR,
+    examples_dir: Path = EXAMPLES_DIR,
+    cross_ref_map: Path = CROSS_REF_MAP,
+) -> tuple:
+    """
+    Run all checks. Returns (errors, warnings).
+    errors   → CI-blocking (broken paths, malformed sections)
+    warnings → non-blocking (missing sections, zero coverage, map drift)
+
+    Check 1: Malformed bullet item in Related examples section
+    Check 2: Referenced example file does not exist on disk
+    Check 3: Skill has no ## Related examples section
+    Check 4: Skill has 0 valid examples listed
+    Check 5: cross-reference-map.md coverage table missing a row for this skill
+    """
+    errors: list = []
+    warnings: list = []
+
+    for d in (skills_dir, examples_dir):
+        if not d.exists():
+            errors.append(f"ERROR: required directory not found: {d}")
+    if errors:
+        return errors, warnings
+
+    map_text = cross_ref_map.read_text(encoding="utf-8") if cross_ref_map.exists() else ""
+
+    for skill_file in sorted(skills_dir.glob("*.md")):
+        skill_path = f"skills/{skill_file.name}"
+        has_section, example_paths, malformed = parse_skill(skill_file)
+
+        # Check 3: No section at all
+        if not has_section:
+            warnings.append(
+                f"WARNING: {skill_path} has no '## Related examples' section."
+            )
+            continue
+
+        # Check 1: Malformed items
+        for item in malformed:
+            errors.append(
+                f"ERROR: {skill_path} 'Related examples': malformed list item: {item!r}"
+            )
+
+        # Check 2: Broken paths
+        for ex_path in example_paths:
+            if not (examples_dir.parent / ex_path).exists():
+                errors.append(
+                    f"ERROR: {skill_path} references {ex_path} but file not found."
+                )
+
+        # Check 4: Zero coverage (section present but lists nothing valid)
+        valid_paths = [p for p in example_paths if (examples_dir.parent / p).exists()]
+        if len(valid_paths) == 0:
+            warnings.append(
+                f"WARNING: {skill_path} 'Related examples' lists 0 valid examples."
+            )
+
+        # Check 5: Map drift
+        row_present = (skill_path in map_text) and ("Example Coverage" in map_text)
+        if not row_present:
+            warnings.append(
+                f"WARNING: cross-reference-map.md 'Skill → Example Coverage' "
+                f"may be missing row for {skill_path}."
+            )
+
+    return errors, warnings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate skill→example coverage in skills/."
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix missing Related examples sections (not yet implemented).",
+    )
+    args = parser.parse_args()
+
+    if args.fix:
+        print("--fix mode is not yet implemented.")
+        sys.exit(0)
+
+    errors, warnings = run_checks()
+
+    for w in warnings:
+        print(w)
+    for e in errors:
+        print(e)
+
+    if not errors and not warnings:
+        print("✓ All example coverage checks passed.")
+    elif not errors:
+        print("✓ No errors. See warnings above.")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_example_coverage.py
+++ b/scripts/validate_example_coverage.py
@@ -21,7 +21,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent
 SKILLS_DIR = REPO_ROOT / "skills"
 EXAMPLES_DIR = REPO_ROOT / "examples"
-CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"
+CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"  # used in run_checks
 
 # Heading aliases — add future multilingual aliases here.
 # Matching is case-insensitive and strips leading #, digits, §, and whitespace.
@@ -90,7 +90,7 @@ def _extract_example_paths(section_text: str) -> list:
         normalized = re.sub(r"^\.\./", "", raw_path)
         if normalized.startswith("examples/"):
             paths.append(normalized)
-    return paths
+    return list(dict.fromkeys(paths))
 
 
 def _find_malformed_items(section_text: str) -> list:

--- a/scripts/validate_example_coverage.py
+++ b/scripts/validate_example_coverage.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+validate_example_coverage.py
+Saudi Legal AI Framework — skill → example coverage validator
+
+Checks that every skills/*.md file has a ## Related examples section and that
+all referenced example files exist on disk.
+
+Usage:
+    python scripts/validate_example_coverage.py          # validate
+    python scripts/validate_example_coverage.py --fix    # auto-fix (not yet implemented)
+
+Exit codes: 0 = pass, 1 = errors found
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+EXAMPLES_DIR = REPO_ROOT / "examples"
+CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"
+
+# Heading aliases — add future multilingual aliases here.
+# Matching is case-insensitive and strips leading #, digits, §, and whitespace.
+RELATED_EXAMPLES_HEADING_ALIASES = [
+    "related examples",
+    "أمثلة مرتبطة",
+]
+
+COVERAGE_STRONG = 2
+COVERAGE_PARTIAL = 1
+
+
+def _normalize_heading(line: str) -> str:
+    """Strip leading #, section numbers (11., §11), and lowercase."""
+    text = re.sub(r"^#+\s*", "", line)
+    text = re.sub(r"^\d+\.\s*", "", text)
+    text = re.sub(r"§\d+\s*", "", text)
+    return text.strip().lower()
+
+
+def _is_related_examples_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in RELATED_EXAMPLES_HEADING_ALIASES)
+
+
+def _heading_level(line: str) -> int:
+    m = re.match(r"^(#+)", line)
+    return len(m.group(1)) if m else 0
+
+
+def _extract_section(lines: list, heading_predicate) -> str:
+    """Return the text body of the first section matching heading_predicate."""
+    in_section = False
+    section_level = 0
+    body: list = []
+    for line in lines:
+        if not in_section:
+            if line.startswith("#") and heading_predicate(line):
+                in_section = True
+                section_level = _heading_level(line)
+        else:
+            lvl = _heading_level(line)
+            if line.startswith("#") and lvl <= section_level:
+                break
+            body.append(line)
+    return "\n".join(body)
+
+
+def _has_section_heading(lines: list, heading_predicate) -> bool:
+    """Return True if any line is a heading matching heading_predicate."""
+    return any(
+        line.startswith("#") and heading_predicate(line)
+        for line in lines
+    )
+
+
+def _extract_example_paths(section_text: str) -> list:
+    """
+    Return list of example path strings (relative to repo root, e.g. 'examples/foo.md')
+    from markdown links in the section. Accepts both '../examples/foo.md' and
+    'examples/foo.md' forms.
+    """
+    paths = []
+    for m in re.finditer(r"\[([^\]]*)\]\(([^)]+)\)", section_text):
+        raw_path = m.group(2)
+        normalized = re.sub(r"^\.\./", "", raw_path)
+        if normalized.startswith("examples/"):
+            paths.append(normalized)
+    return paths
+
+
+def _find_malformed_items(section_text: str) -> list:
+    """
+    Return list of bullet items (lines starting with * or -) that contain no
+    markdown link whose path resolves to examples/. These are structurally
+    malformed entries that should be fixed.
+    """
+    malformed = []
+    for line in section_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith(("*", "-")):
+            continue
+        has_example_link = bool(
+            re.search(r"\[([^\]]*)\]\(\.\./examples/[\w.-]+\)", stripped)
+            or re.search(r"\[([^\]]*)\]\(examples/[\w.-]+\)", stripped)
+        )
+        if not has_example_link:
+            malformed.append(stripped)
+    return malformed
+
+
+def parse_skill(path: Path) -> tuple:
+    """
+    Parse a skill file for its Related examples section.
+
+    Returns (has_section, example_paths, malformed_items):
+    - has_section: True if a ## Related examples heading was found
+    - example_paths: list of normalized paths like 'examples/foo.md'
+    - malformed_items: bullet items without a valid examples/ link
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    has_section = _has_section_heading(lines, _is_related_examples_heading)
+    if not has_section:
+        return False, [], []
+    section_text = _extract_section(lines, _is_related_examples_heading)
+    return True, _extract_example_paths(section_text), _find_malformed_items(section_text)
+
+
+def coverage_status(count: int) -> str:
+    """Return 'Strong', 'Partial', or 'Missing' based on example count."""
+    if count >= COVERAGE_STRONG:
+        return "Strong"
+    if count == COVERAGE_PARTIAL:
+        return "Partial"
+    return "Missing"

--- a/scripts/validate_skill_graph.py
+++ b/scripts/validate_skill_graph.py
@@ -273,7 +273,7 @@ def format_stats(stats: dict) -> str:
         f"{t}\xd7{c}"
         for t, c in sorted(stats["type_counts"].items(), key=lambda x: -x[1])
     ) or "(none)"
-    most_conn = ", ".join(stats["most_connected"]) if stats["most_connected"] else "—"
+    most_conn = ", ".join(stats["most_connected"]) if stats["edges"] > 0 else "—"
     orphan_str = ", ".join(stats["orphans"]) if stats["orphans"] else "none"
     return "\n".join([
         "── Skill Graph Summary ───────────────────────────",
@@ -309,6 +309,7 @@ def run_checks(
     """
     errors: list = []
     warnings: list = []
+    no_section_skills: set = set()
 
     if not skills_dir.exists():
         errors.append(f"ERROR: required directory not found: {skills_dir}")
@@ -327,6 +328,7 @@ def run_checks(
             warnings.append(
                 f"WARNING: {skill_path} has no '## Related skills' section."
             )
+            no_section_skills.add(skill_path)
             graph[skill_path] = []
             continue
 
@@ -376,9 +378,10 @@ def run_checks(
 
     # W2: Orphan skills
     for orphan in stats["orphans"]:
-        warnings.append(
-            f"WARNING: {orphan} appears to be an orphan (0 in-edges and 0 out-edges)."
-        )
+        if orphan not in no_section_skills:
+            warnings.append(
+                f"WARNING: {orphan} appears to be an orphan (0 in-edges and 0 out-edges)."
+            )
 
     # W3: Asymmetric relationships (informational)
     for src, src_edges in graph.items():

--- a/scripts/validate_skill_graph.py
+++ b/scripts/validate_skill_graph.py
@@ -79,6 +79,7 @@ def _extract_section(lines: list, heading_predicate) -> str:
 
 
 def _has_section_heading(lines: list, heading_predicate) -> bool:
+    """Return True if any line is a heading matching heading_predicate."""
     return any(
         line.startswith("#") and heading_predicate(line)
         for line in lines
@@ -115,7 +116,7 @@ def _extract_skill_edges(section_text: str) -> list:
                     j += 1
                 if j < len(lines):
                     rel_m = re.match(
-                        r'^\s*[—\-]\s*relationship:\s*(\S+)',
+                        r'^\s*[—\-]\s*relationship:\s*([A-Za-z_]+)\s*$',
                         lines[j],
                     )
                     if rel_m:
@@ -167,7 +168,7 @@ def _find_malformed_entries(section_text: str) -> list:
             while j < len(lines) and not lines[j].strip():
                 j += 1
             if j >= len(lines) or not re.match(
-                r'^\s*[—\-]\s*relationship:\s*\S+', lines[j]
+                r'^\s*[—\-]\s*relationship:\s*[A-Za-z_]+\s*$', lines[j]
             ):
                 malformed.append(stripped)
                 i += 1

--- a/scripts/validate_skill_graph.py
+++ b/scripts/validate_skill_graph.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+validate_skill_graph.py
+Saudi Legal AI Framework — typed skill relationship graph validator
+
+Checks that every skills/*.md file has a ## Related skills section with
+well-formed, typed edges pointing to existing skills.
+
+Exit codes: 0 = pass (or warnings only), 1 = errors found
+"""
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"
+
+RELATED_SKILLS_HEADING_ALIASES = [
+    "related skills",
+    "مهارات مرتبطة",
+]
+
+ALLOWED_RELATIONSHIP_TYPES = {
+    "escalates_to",
+    "alternative_to",
+    "cross_checks",
+    "depends_on",
+    "specializes",
+    "precedes",
+    "shares_sources_with",
+    "overlaps_with",
+}
+
+
+@dataclass(frozen=True)
+class Edge:
+    target: str        # normalized: "skills/foo.md"
+    relationship: str  # must be in ALLOWED_RELATIONSHIP_TYPES
+    rationale: str     # free text description
+
+
+def _normalize_heading(line: str) -> str:
+    """Strip leading #, section numbers (e.g. 11., §11), and lowercase."""
+    text = re.sub(r"^#+\s*", "", line)
+    text = re.sub(r"^\d+\.\s*", "", text)
+    text = re.sub(r"§\d+\s*", "", text)
+    return text.strip().lower()
+
+
+def _is_related_skills_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in RELATED_SKILLS_HEADING_ALIASES)
+
+
+def _heading_level(line: str) -> int:
+    m = re.match(r"^(#+)", line)
+    return len(m.group(1)) if m else 0
+
+
+def _extract_section(lines: list, heading_predicate) -> str:
+    """Return the text body of the first section matching heading_predicate."""
+    in_section = False
+    section_level = 0
+    body: list = []
+    for line in lines:
+        if not in_section:
+            if line.startswith("#") and heading_predicate(line):
+                in_section = True
+                section_level = _heading_level(line)
+        else:
+            lvl = _heading_level(line)
+            if line.startswith("#") and lvl <= section_level:
+                break
+            body.append(line)
+    return "\n".join(body)
+
+
+def _has_section_heading(lines: list, heading_predicate) -> bool:
+    return any(
+        line.startswith("#") and heading_predicate(line)
+        for line in lines
+    )
+
+
+def _extract_skill_edges(section_text: str) -> list:
+    """
+    Parse 3-line edge blocks from a ## Related skills section body.
+
+    Expected format per edge:
+        * [label](../skills/foo.md)
+          — relationship: escalates_to
+          — rationale text
+
+    Returns only structurally valid blocks. Malformed blocks are reported
+    separately by _find_malformed_entries and validated in run_checks.
+    """
+    lines = [ln.rstrip() for ln in section_text.splitlines()]
+    edges = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith(("* ", "- ")):
+            m = re.search(
+                r'\[([^\]]*)\]\((?:\.\./)?(skills/[\w.-]+\.md)\)',
+                stripped,
+            )
+            if m:
+                target = m.group(2)
+                # Find next non-blank line: — relationship: <type>
+                j = i + 1
+                while j < len(lines) and not lines[j].strip():
+                    j += 1
+                if j < len(lines):
+                    rel_m = re.match(
+                        r'^\s*[—\-]\s*relationship:\s*(\S+)',
+                        lines[j],
+                    )
+                    if rel_m:
+                        relationship = rel_m.group(1)
+                        # Find next non-blank line: — <rationale>
+                        k = j + 1
+                        while k < len(lines) and not lines[k].strip():
+                            k += 1
+                        if k < len(lines):
+                            rat_m = re.match(
+                                r'^\s*[—\-]\s*(.+)',
+                                lines[k],
+                            )
+                            if rat_m:
+                                edges.append(
+                                    Edge(
+                                        target=target,
+                                        relationship=relationship,
+                                        rationale=rat_m.group(1).strip(),
+                                    )
+                                )
+        i += 1
+    return edges
+
+
+def _find_malformed_entries(section_text: str) -> list:
+    """
+    Return bullet lines that are structurally malformed:
+    - Bullet with no link to skills/
+    - Bullet with skills/ link but missing — relationship: line
+    - Bullet with skills/ link and relationship: but missing rationale line
+    """
+    lines = [ln.rstrip() for ln in section_text.splitlines()]
+    malformed = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith(("* ", "- ")):
+            m = re.search(
+                r'\[([^\]]*)\]\((?:\.\./)?(skills/[\w.-]+\.md)\)',
+                stripped,
+            )
+            if not m:
+                malformed.append(stripped)
+                i += 1
+                continue
+            # Has skills link — check for relationship: line
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                j += 1
+            if j >= len(lines) or not re.match(
+                r'^\s*[—\-]\s*relationship:\s*\S+', lines[j]
+            ):
+                malformed.append(stripped)
+                i += 1
+                continue
+            # Check for rationale line
+            k = j + 1
+            while k < len(lines) and not lines[k].strip():
+                k += 1
+            if k >= len(lines) or not re.match(r'^\s*[—\-]\s*.+', lines[k]):
+                malformed.append(stripped)
+        i += 1
+    return malformed
+
+
+def parse_skill(path: Path) -> tuple:
+    """
+    Parse a skill file for its Related skills section.
+
+    Returns (has_section, edges, malformed_entries):
+    - has_section: True if ## Related skills heading found
+    - edges: list of Edge (structurally valid blocks only)
+    - malformed_entries: list of malformed bullet line strings
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    has_section = _has_section_heading(lines, _is_related_skills_heading)
+    if not has_section:
+        return False, [], []
+    section_text = _extract_section(lines, _is_related_skills_heading)
+    return (
+        True,
+        _extract_skill_edges(section_text),
+        _find_malformed_entries(section_text),
+    )

--- a/scripts/validate_skill_graph.py
+++ b/scripts/validate_skill_graph.py
@@ -202,3 +202,216 @@ def parse_skill(path: Path) -> tuple:
         _extract_skill_edges(section_text),
         _find_malformed_entries(section_text),
     )
+
+
+def _count_components(all_nodes: set, graph: dict) -> int:
+    """Count weakly connected components (treating edges as undirected)."""
+    adjacency: dict = {n: set() for n in all_nodes}
+    for src, edges in graph.items():
+        for e in edges:
+            adjacency.setdefault(src, set()).add(e.target)
+            adjacency.setdefault(e.target, set()).add(src)
+
+    visited: set = set()
+    components = 0
+    for start in all_nodes:
+        if start not in visited:
+            components += 1
+            queue = [start]
+            while queue:
+                node = queue.pop()
+                if node in visited:
+                    continue
+                visited.add(node)
+                queue.extend(adjacency.get(node, set()) - visited)
+    return components
+
+
+def graph_stats(graph: dict) -> dict:
+    """
+    Compute summary statistics for the skill graph.
+
+    graph: dict mapping "skills/source.md" -> list[Edge]
+    Returns a dict with keys: nodes, edges, orphans, most_connected,
+    type_counts, components.
+    """
+    all_nodes: set = set(graph.keys())
+    for edges in graph.values():
+        for e in edges:
+            all_nodes.add(e.target)
+
+    out_degree = {n: len(graph.get(n, [])) for n in all_nodes}
+    in_degree: dict = {n: 0 for n in all_nodes}
+    for edges in graph.values():
+        for e in edges:
+            in_degree[e.target] = in_degree.get(e.target, 0) + 1
+
+    total_degree = {n: out_degree.get(n, 0) + in_degree.get(n, 0) for n in all_nodes}
+    orphans = sorted(n for n in all_nodes if total_degree[n] == 0)
+    most_connected = sorted(all_nodes, key=lambda n: total_degree[n], reverse=True)
+
+    type_counts: dict = {}
+    total_edges = 0
+    for edges in graph.values():
+        for e in edges:
+            type_counts[e.relationship] = type_counts.get(e.relationship, 0) + 1
+            total_edges += 1
+
+    return {
+        "nodes": len(all_nodes),
+        "edges": total_edges,
+        "orphans": orphans,
+        "most_connected": most_connected[:3],
+        "type_counts": type_counts,
+        "components": _count_components(all_nodes, graph) if all_nodes else 0,
+    }
+
+
+def format_stats(stats: dict) -> str:
+    """Format graph statistics for stdout display."""
+    type_str = "  ".join(
+        f"{t}\xd7{c}"
+        for t, c in sorted(stats["type_counts"].items(), key=lambda x: -x[1])
+    ) or "(none)"
+    most_conn = ", ".join(stats["most_connected"]) if stats["most_connected"] else "—"
+    orphan_str = ", ".join(stats["orphans"]) if stats["orphans"] else "none"
+    return "\n".join([
+        "── Skill Graph Summary ───────────────────────────",
+        f"  Nodes (skills):        {stats['nodes']}",
+        f"  Edges (relationships): {stats['edges']}",
+        f"  Orphan skills:         {orphan_str}",
+        f"  Most connected:        {most_conn}",
+        f"  Relationship types:    {type_str}",
+        f"  Connectivity:          {stats['components']} component(s)",
+        "─" * 49,
+    ])
+
+
+def run_checks(
+    skills_dir: Path = SKILLS_DIR,
+    cross_ref_map: Path = CROSS_REF_MAP,
+) -> tuple:
+    """
+    Run all validation checks. Returns (errors, warnings, stats).
+
+    Errors (CI-blocking, exit 1):
+      E1: required skills/ directory missing
+      E2: referenced skill file does not exist on disk
+      E3: invalid relationship type
+      E4: malformed entry structure
+      E5: self-reference
+
+    Warnings (non-blocking, exit 0):
+      W1: skill has no ## Related skills section
+      W2: orphan skill (0 in-edges and 0 out-edges across full graph)
+      W3: asymmetric relationship (informational)
+      W4: cross-reference-map missing Skill Relationship Graph row
+    """
+    errors: list = []
+    warnings: list = []
+
+    if not skills_dir.exists():
+        errors.append(f"ERROR: required directory not found: {skills_dir}")
+        return errors, warnings, {}
+
+    map_text = cross_ref_map.read_text(encoding="utf-8") if cross_ref_map.exists() else ""
+
+    graph: dict = {}
+
+    for skill_file in sorted(skills_dir.glob("*.md")):
+        skill_path = f"skills/{skill_file.name}"
+        has_section, edges, malformed = parse_skill(skill_file)
+
+        # W1: No section
+        if not has_section:
+            warnings.append(
+                f"WARNING: {skill_path} has no '## Related skills' section."
+            )
+            graph[skill_path] = []
+            continue
+
+        graph[skill_path] = []
+
+        # E4: Malformed entries
+        for item in malformed:
+            errors.append(
+                f"ERROR: {skill_path} 'Related skills': malformed entry: {item!r}"
+            )
+
+        for edge in edges:
+            # E5: Self-reference
+            if edge.target == skill_path:
+                errors.append(
+                    f"ERROR: {skill_path} has a self-reference in 'Related skills'."
+                )
+                continue
+
+            # E2: Broken path
+            if not (skills_dir.parent / edge.target).exists():
+                errors.append(
+                    f"ERROR: {skill_path} references {edge.target!r} but file not found."
+                )
+                continue
+
+            # E3: Invalid relationship type
+            if edge.relationship not in ALLOWED_RELATIONSHIP_TYPES:
+                errors.append(
+                    f"ERROR: {skill_path} uses unknown relationship type "
+                    f"{edge.relationship!r} (→ {edge.target})."
+                )
+                continue
+
+            graph[skill_path].append(edge)
+
+        # W4: Map drift
+        row_present = (skill_path in map_text) and ("Skill Relationship Graph" in map_text)
+        if not row_present:
+            warnings.append(
+                f"WARNING: cross-reference-map.md 'Skill Relationship Graph' "
+                f"may be missing row for {skill_path}."
+            )
+
+    # Compute stats over full graph
+    stats = graph_stats(graph)
+
+    # W2: Orphan skills
+    for orphan in stats["orphans"]:
+        warnings.append(
+            f"WARNING: {orphan} appears to be an orphan (0 in-edges and 0 out-edges)."
+        )
+
+    # W3: Asymmetric relationships (informational)
+    for src, src_edges in graph.items():
+        for e in src_edges:
+            target_edges = graph.get(e.target, [])
+            reverse_exists = any(te.target == src for te in target_edges)
+            if not reverse_exists:
+                warnings.append(
+                    f"WARNING: asymmetric — {src} → {e.target} "
+                    f"({e.relationship}) has no reverse edge."
+                )
+
+    return errors, warnings, stats
+
+
+def main() -> None:
+    errors, warnings, stats = run_checks()
+
+    if stats:
+        print(format_stats(stats))
+
+    for w in warnings:
+        print(w)
+    for e in errors:
+        print(e)
+
+    if not errors and not warnings:
+        print("✓ All skill graph checks passed.")
+    elif not errors:
+        print("✓ No errors. See warnings above.")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/arbitration.md
+++ b/skills/arbitration.md
@@ -403,6 +403,18 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [commercial-dispute.md](../skills/commercial-dispute.md)
+  — relationship: alternative_to
+  — Commercial Court litigation is the fallback when arbitration is excluded, waived, or fails
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: depends_on
+  — arbitration requests, submissions, and award enforcement filings require legal drafting
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/arbitration-example.md](../examples/arbitration-example.md) — cross-border supply dispute: enforcing a DIAC arbitration clause under Saudi law

--- a/skills/arbitration.md
+++ b/skills/arbitration.md
@@ -400,3 +400,9 @@ What AI cannot assess in this context:
 - **قواعد SCCA المحدثة:** تتغير - راجع scca.org.sa دائما.
 - **قائمة المسائل غير القابلة للتحكيم:** في تطور - يرجى التحقق مع محامٍ متخصص.
 - **تنفيذ الاحكام الاجنبية:** يختلف بحسب الدولة وطبيعة النزاع - **TO VERIFY** في كل حالة.
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/arbitration-example.md](../examples/arbitration-example.md) — cross-border supply dispute: enforcing a DIAC arbitration clause under Saudi law

--- a/skills/commercial-dispute.md
+++ b/skills/commercial-dispute.md
@@ -415,6 +415,18 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [arbitration.md](../skills/arbitration.md)
+  — relationship: alternative_to
+  — arbitration replaces court litigation when a valid arbitration clause exists or parties agree
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: precedes
+  — formal demand notices must be drafted before court filing
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/commercial-dispute-example.md](../examples/commercial-dispute-example.md) — commercial dispute analysis under Saudi commercial courts framework

--- a/skills/commercial-dispute.md
+++ b/skills/commercial-dispute.md
@@ -412,3 +412,9 @@ What AI cannot assess in this context:
 - **تنفيذ الأحكام الأجنبية:** تختلف بحسب الدولة واتفاقيات المعاملة بالمثل — **TO VERIFY** لكل دولة.
 - **عتبات اختصاص هيئة المنافسة:** تتغير — تحقق من اللوائح الحالية.
 - **جداول التقاضي في المحاكم التجارية:** تتغير — استعلم من najiz.sa.
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/commercial-dispute-example.md](../examples/commercial-dispute-example.md) — commercial dispute analysis under Saudi commercial courts framework

--- a/skills/commercial-dispute.md
+++ b/skills/commercial-dispute.md
@@ -423,7 +423,7 @@ What AI cannot assess in this context:
 
 * [legal-drafting.md](../skills/legal-drafting.md)
   — relationship: precedes
-  — formal demand notices must be drafted before court filing
+  — dispute analysis identifies the claim basis and parties; a formal demand letter (إنذار) must then be drafted as a procedural prerequisite before filing with the Commercial Court
 
 ---
 

--- a/skills/compliance-check.md
+++ b/skills/compliance-check.md
@@ -391,3 +391,10 @@ What AI cannot assess in this context:
 - **ضريبة الاستقطاع (WHT):** تختلف نسبها حسب نوع الخدمة والدولة — **TO VERIFY** مع مستشار ضريبي.
 - **عتبات التسجيل في VAT:** راجع آخر تعليمات ZATCA على zatca.gov.sa.
 - **اشتراطات AML/CFT القطاعية:** تختلف حسب القطاع — تحقق من وحدة الاستخبارات المالية.
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/compliance-example.md](../examples/compliance-example.md) — SaaS startup compliance assessment (PDPL, Nitaqat, WPS)
+* [examples/pdpl-data-breach-example.md](../examples/pdpl-data-breach-example.md) — medical data breach: PDPL notification obligations and response workflow

--- a/skills/compliance-check.md
+++ b/skills/compliance-check.md
@@ -394,6 +394,14 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [labor-law-analysis.md](../skills/labor-law-analysis.md)
+  — relationship: cross_checks
+  — Nitaqat (Saudization), WPS, and GOSI compliance are labor law sub-domains that require cross-verification
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/compliance-example.md](../examples/compliance-example.md) — SaaS startup compliance assessment (PDPL, Nitaqat, WPS)

--- a/skills/compliance-check.md
+++ b/skills/compliance-check.md
@@ -400,6 +400,10 @@ What AI cannot assess in this context:
   — relationship: cross_checks
   — Nitaqat (Saudization), WPS, and GOSI compliance are labor law sub-domains that require cross-verification
 
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: cross_checks
+  — contracts flagged for PDPL, Nitaqat, or WPS terms must be cross-checked against the compliance assessment framework
+
 ---
 
 ## Related examples / أمثلة مرتبطة

--- a/skills/contract-review.md
+++ b/skills/contract-review.md
@@ -453,6 +453,26 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [commercial-dispute.md](../skills/commercial-dispute.md)
+  — relationship: escalates_to
+  — unresolved contract breach or contested clause may require Commercial Court proceedings
+
+* [arbitration.md](../skills/arbitration.md)
+  — relationship: escalates_to
+  — an arbitration clause in the contract activates this path instead of court litigation
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: precedes
+  — review identifies gaps and red flags; legal-drafting is then used to address them
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: cross_checks
+  — contracts containing PDPL clauses, Nitaqat obligations, or WPS terms need compliance verification
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/contract-review-example.md](../examples/contract-review-example.md) — professional services contract review: foreign governing law clause, interest, IP transfer

--- a/skills/contract-review.md
+++ b/skills/contract-review.md
@@ -450,3 +450,12 @@ What AI cannot assess in this context:
 - **الشروط التعليقية المعقدة:** التوافق مع أحكام الفقه الإسلامي يستلزم متخصصًا شرعيًا.
 - **التحكيم التجاري مع طرف أجنبي:** ليس ممنوعًا كليًا — لكن يحتاج تقييمًا قانونيًا للحالة.
 - **اشتراطات التوثيق والتسجيل:** تتطور — تحقق من الجهة المختصة عند صياغة كل وثيقة.
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/contract-review-example.md](../examples/contract-review-example.md) — professional services contract review: foreign governing law clause, interest, IP transfer
+* [examples/employment-contract-review.md](../examples/employment-contract-review.md) — employment contract review: Saudi national, full §8 output demonstration
+* [examples/nda-review.md](../examples/nda-review.md) — NDA review: confidentiality scope, PDPL alignment, enforceability
+* [examples/saudi-contract-review-demo.md](../examples/saudi-contract-review-demo.md) — full 9-section contract review workflow demo (authoritative §8 reference)

--- a/skills/labor-law-analysis.md
+++ b/skills/labor-law-analysis.md
@@ -409,3 +409,11 @@ What AI cannot assess in this context:
 - **نسب نطاقات الحالية:** تتغير دوريًا — تحقق من منصة مسار دائمًا.
 - **أحكام التأمينات للوافدين:** في تطور — راجع آخر لوائح GOSI على gosi.gov.sa.
 - **تعديلات نظام العمل:** تصدر قرارات وزارية بانتظام — تحقق من النص الساري على boe.gov.sa.
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/employment-contract-review.md](../examples/employment-contract-review.md) — employment contract review: mandatory elements check under Saudi Labour Law
+* [examples/labor-dispute-job-change-example.md](../examples/labor-dispute-job-change-example.md) — unilateral job title and salary change without employee consent
+* [examples/labor-law-example.md](../examples/labor-law-example.md) — EOSB calculation and wrongful termination analysis (7-year employee)

--- a/skills/labor-law-analysis.md
+++ b/skills/labor-law-analysis.md
@@ -412,6 +412,18 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: cross_checks
+  — employment compliance dimensions (PDPL over HR data, Saudization quotas) cross both domains
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: depends_on
+  — employment contracts are analysed using the contract-review methodology for clause-level risk
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/employment-contract-review.md](../examples/employment-contract-review.md) — employment contract review: mandatory elements check under Saudi Labour Law

--- a/skills/legal-drafting.md
+++ b/skills/legal-drafting.md
@@ -401,3 +401,9 @@ What automated drafting cannot guarantee:
 - **بنود التحكيم الخارجي في العقود التجارية:** مسموح به مع قيود — **TO VERIFY** في كل حالة.
 - **نظام حماية الملكية الفكرية م/41:** صدرت تعديلات — تحقق من النص الساري على boe.gov.sa.
 - **الترجمة المعتمدة:** يستلزم مترجمًا قانونيًا معتمدًا من وزارة العدل لأغراض التقاضي.
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/legal-drafting-example.md](../examples/legal-drafting-example.md) — software services contract drafting: milestone-linked payments, IP, PDPL clauses

--- a/skills/legal-drafting.md
+++ b/skills/legal-drafting.md
@@ -404,6 +404,14 @@ What automated drafting cannot guarantee:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: depends_on
+  — quality criteria for drafted documents are grounded in contract-review red flags and mandatory clause checklists
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/legal-drafting-example.md](../examples/legal-drafting-example.md) — software services contract drafting: milestone-linked payments, IP, PDPL clauses

--- a/skills/real-estate-contracts.md
+++ b/skills/real-estate-contracts.md
@@ -407,6 +407,18 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: specializes
+  — real estate contracts are a domain-scoped application of the general contract review methodology
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: depends_on
+  — Ejar registration, municipal approvals, and REGA requirements are compliance obligations
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/commercial-lease-exit-example.md](../examples/commercial-lease-exit-example.md) — early exit from commercial lease: penalty clause enforceability

--- a/skills/real-estate-contracts.md
+++ b/skills/real-estate-contracts.md
@@ -404,3 +404,10 @@ What AI cannot assess in this context:
 - **تسجيل الملكية العينية:** يختلف التطبيق بحسب المنطقة والوضع الراهن - استفسر من وزارة العدل.
 - **قيود تملك الاجانب:** تتطور - راجع آخر ضوابط هيئة الاستثمار (investsaudi.gov.sa).
 - **لجان الفصل في منازعات الايجار:** الاجراءات وامكنة اللجان في تطور - راجع rega.gov.sa.
+
+---
+
+## Related examples / أمثلة مرتبطة
+
+* [examples/commercial-lease-exit-example.md](../examples/commercial-lease-exit-example.md) — early exit from commercial lease: penalty clause enforceability
+* [examples/real-estate-example.md](../examples/real-estate-example.md) — residential lease renewal dispute: Ejar platform registration and rent increase limits

--- a/sources/civil-transactions-law.md
+++ b/sources/civil-transactions-law.md
@@ -492,3 +492,20 @@ Western "force majeure" clauses do not necessarily mirror Article 96. The defini
 <!-- TODO: يحتاج تحقق — رقم مادة مسؤولية المتبوع عن التابع وحارس الشيء (132 ام 134) -->
 <!-- TODO: يحتاج تحقق — مدة طلب ابطال العقد لعيوب الإرادة ورقم مادتها -->
 <!-- TODO: يحتاج تحقق — نطاقات مواد العقود المسماة (إيجار ووكالة ومقاولة وغيرها) -->
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/labor-law-analysis.md](../skills/labor-law-analysis.md) | §11 الأنظمة ذات الصلة | مبادئ العقود التكميلية |
+| [skills/commercial-dispute.md](../skills/commercial-dispute.md) | §11 الأنظمة ذات الصلة | العقود والالتزامات — أساس المطالبات |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | التزامات تعاقدية تنظيمية |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة ذات الصلة | الإطار العام للعقود والالتزامات |
+| [skills/arbitration.md](../skills/arbitration.md) | §11 الأنظمة ذات الصلة | مبادئ العقود والالتزامات في النزاعات |
+| [skills/real-estate-contracts.md](../skills/real-estate-contracts.md) | §11 الأنظمة ذات الصلة | مبادئ العقود والالتزامات العامة |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)

--- a/sources/commercial-courts.md
+++ b/sources/commercial-courts.md
@@ -306,3 +306,17 @@ The Ministry of Justice Legal Portal is the official reference for regulations a
 | **نوع المصدر** | رسمي |
 | **الاستخدام في هذا المشروع** | فهرسة الأحكام القضائية التجارية في `datasets/judicial-decisions/commercial/` |
 <!-- TODO: يحتاج تحقق — إجراءات التنفيذ الحديثة عبر ناجز وهل تغيرت بعد 1441هـ -->
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/commercial-dispute.md](../skills/commercial-dispute.md) | §11 الأنظمة ذات الصلة | الإطار الإجرائي الأساسي |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | فض النزاعات التنظيمية |
+| [skills/arbitration.md](../skills/arbitration.md) | §11 الأنظمة ذات الصلة | الرقابة القضائية على التحكيم وتنفيذ الاحكام |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)

--- a/sources/companies-law.md
+++ b/sources/companies-law.md
@@ -300,3 +300,18 @@ The single-person company form is new under the 2022 Companies Law; judicial and
 <!-- TODO: يحتاج تحقق من النص النظامي الرسمي — أرقام المواد الدقيقة لجميع الأحكام الإلزامية في نظام الشركات م/132 1443هـ -->
 <!-- TODO: يحتاج تحقق — هل الحد الأدنى لرأس المال لشركة المساهمة محدد في النظام أم مترك للنظام الأساسي؟ -->
 <!-- TODO: يحتاج تحقق — اشتراطات الأعضاء المستقلين في مجلس إدارة الشركات المحدودة غير المدرجة -->
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/commercial-dispute.md](../skills/commercial-dispute.md) | §11 الأنظمة ذات الصلة | نزاعات المساهمين والشركاء |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | هيكل الملكية ومتطلبات الإفصاح |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة ذات الصلة | وثائق الشركات والمساهمين |
+| [skills/real-estate-contracts.md](../skills/real-estate-contracts.md) | §11 الأنظمة ذات الصلة | عقارات الشركات والتصرف فيها |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)

--- a/sources/labor-law.md
+++ b/sources/labor-law.md
@@ -391,3 +391,17 @@ The 15-day-per-year figure is a statutory floor, not a cap. Labor courts may awa
 <!-- TODO: يحتاج تحقق من النص النظامي الرسمي — أرقام المواد الدقيقة لجميع الأحكام الإلزامية أعلاه -->
 <!-- TODO: يحتاج تحقق — مدة إشعار الإنهاء للعمال غير ذوي الأجر الشهري -->
 <!-- TODO: يحتاج تحقق — البنود الإلزامية التي أضافتها تعديلات نظام العمل بعد 1426هـ -->
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/labor-law-analysis.md](../skills/labor-law-analysis.md) | §11 الأنظمة ذات الصلة | الإطار الحاكم الأساسي |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | السعودة، WPS، GOSI |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة ذات الصلة | عقود العمل — أحكام آمرة |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)

--- a/sources/pdpl.md
+++ b/sources/pdpl.md
@@ -330,3 +330,17 @@ Some service agreements require users to maintain consent as a condition of cont
 <!-- TODO: يحتاج تحقق من النص النظامي الرسمي — أرقام المواد لجميع الأحكام الإلزامية في نظام PDPL م/19 1443هـ -->
 <!-- TODO: يحتاج تحقق — المعايير الدقيقة لإلزامية تعيين مسؤول حماية البيانات (DPO) -->
 <!-- TODO: يحتاج تحقق — التزامات الإفصاح للمعالجين من الباطن (sub-processors) ومتطلبات عقود المعالجة -->
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/labor-law-analysis.md](../skills/labor-law-analysis.md) | §11 الأنظمة ذات الصلة | بنود السرية في عقود العمل |
+| [skills/compliance-check.md](../skills/compliance-check.md) | §11 الأنظمة ذات الصلة | PDPL — نقل البيانات والخصوصية |
+| [skills/legal-drafting.md](../skills/legal-drafting.md) | §11 الأنظمة ذات الصلة | بنود السرية ومعالجة البيانات |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)

--- a/tests/test_validate_cross_refs.py
+++ b/tests/test_validate_cross_refs.py
@@ -1,0 +1,285 @@
+# tests/test_validate_cross_refs.py
+"""
+Tests for scripts/validate_cross_refs.py
+Saudi Legal AI Framework — reverse-discovery seam validator
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import validate_cross_refs as vcr
+
+
+# ── Heading detection ──────────────────────────────────────────────────────────
+
+def test_normalize_heading_strips_hashes():
+    assert vcr._normalize_heading("## Introduction") == "introduction"
+
+def test_normalize_heading_strips_section_number():
+    assert vcr._normalize_heading("## 11. Relevant Regulations / الأنظمة ذات الصلة") == "relevant regulations / الأنظمة ذات الصلة"
+
+def test_normalize_heading_strips_section_number_with_symbol():
+    assert vcr._normalize_heading("## §11 Relevant Regulations") == "relevant regulations"
+
+def test_is_regulations_heading_english():
+    assert vcr._is_regulations_heading("## 11. Relevant Regulations / الأنظمة ذات الصلة")
+
+def test_is_regulations_heading_arabic():
+    assert vcr._is_regulations_heading("## الأنظمة المرتبطة")
+
+def test_is_regulations_heading_unrelated():
+    assert not vcr._is_regulations_heading("## Introduction")
+
+def test_is_regulations_heading_case_insensitive():
+    assert vcr._is_regulations_heading("## RELEVANT REGULATIONS")
+
+def test_is_see_also_heading():
+    assert vcr._is_see_also_heading("## See also / انظر أيضًا")
+
+def test_is_see_also_heading_plain():
+    assert vcr._is_see_also_heading("## See also")
+
+def test_is_see_also_heading_unrelated():
+    assert not vcr._is_see_also_heading("## Overview")
+
+
+# ── Path extraction ────────────────────────────────────────────────────────────
+
+def test_extract_source_paths_backtick():
+    text = "See `sources/labor-law.md` for details"
+    assert vcr._extract_source_paths(text) == {"sources/labor-law.md"}
+
+def test_extract_source_paths_bare():
+    text = "See sources/pdpl.md in this project"
+    assert vcr._extract_source_paths(text) == {"sources/pdpl.md"}
+
+def test_extract_source_paths_multiple():
+    text = "`sources/labor-law.md` and `sources/pdpl.md`"
+    assert vcr._extract_source_paths(text) == {"sources/labor-law.md", "sources/pdpl.md"}
+
+def test_extract_source_paths_deduplicates():
+    text = "`sources/labor-law.md` appears twice `sources/labor-law.md`"
+    assert vcr._extract_source_paths(text) == {"sources/labor-law.md"}
+
+def test_extract_source_paths_excludes_regulation_index():
+    text = "راجع `sources/regulation-index.md` للصيغ الرسمية"
+    assert "sources/regulation-index.md" not in vcr._extract_source_paths(text)
+
+def test_extract_skill_paths_backtick():
+    text = "Implemented in `skills/contract-review.md`"
+    assert vcr._extract_skill_paths(text) == {"skills/contract-review.md"}
+
+def test_extract_skill_paths_markdown_link():
+    text = "- [skills/contract-review.md](../skills/contract-review.md) — §11"
+    assert vcr._extract_skill_paths(text) == {"skills/contract-review.md"}
+
+
+# ── Section extraction ─────────────────────────────────────────────────────────
+
+def test_extract_section_returns_body(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Introduction\nSome text.\n\n"
+        "## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        "`sources/labor-law.md`\n\n"
+        "## 12. Next Section\nOther content.\n",
+        encoding="utf-8",
+    )
+    body = vcr._extract_section(skill.read_text(encoding="utf-8").splitlines(), vcr._is_regulations_heading)
+    assert "sources/labor-law.md" in body
+    assert "Next Section" not in body
+
+def test_extract_section_not_found_returns_empty(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text("## Introduction\nSome text.\n", encoding="utf-8")
+    body = vcr._extract_section(skill.read_text(encoding="utf-8").splitlines(), vcr._is_regulations_heading)
+    assert body == ""
+
+
+# ── parse_skill ────────────────────────────────────────────────────────────────
+
+def test_parse_skill_finds_sources_in_regulations_section(tmp_path):
+    skill = tmp_path / "labor-law-analysis.md"
+    skill.write_text(
+        "## Introduction\nSome intro.\n\n"
+        "## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        "| نظام العمل | م/51 | الإطار | `sources/labor-law.md` |\n"
+        "| PDPL | م/19 | السرية | `sources/pdpl.md` |\n"
+        "راجع `sources/regulation-index.md` للصيغ الرسمية.\n\n"
+        "## 12. Next\nOther.\n",
+        encoding="utf-8",
+    )
+    result = vcr.parse_skill(skill)
+    assert result == {"sources/labor-law.md", "sources/pdpl.md"}
+    assert "sources/regulation-index.md" not in result
+
+def test_parse_skill_ignores_sources_outside_regulations(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Introduction\nSee `sources/other.md` here.\n\n"
+        "## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        "`sources/labor-law.md`\n\n"
+        "## 12. Next\n",
+        encoding="utf-8",
+    )
+    assert vcr.parse_skill(skill) == {"sources/labor-law.md"}
+
+def test_parse_skill_arabic_heading(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## الأنظمة المرتبطة\n`sources/civil-transactions-law.md`\n\n## Next\n",
+        encoding="utf-8",
+    )
+    assert vcr.parse_skill(skill) == {"sources/civil-transactions-law.md"}
+
+def test_parse_skill_no_regulations_section_returns_empty(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text("## Introduction\nNo regulations here.\n", encoding="utf-8")
+    assert vcr.parse_skill(skill) == set()
+
+
+# ── parse_source ───────────────────────────────────────────────────────────────
+
+def test_parse_source_no_see_also(tmp_path):
+    source = tmp_path / "labor-law.md"
+    source.write_text("## Overview\nSome content.\n", encoding="utf-8")
+    has_see_also, skills = vcr.parse_source(source)
+    assert not has_see_also
+    assert skills == set()
+
+def test_parse_source_with_see_also_backtick(tmp_path):
+    source = tmp_path / "labor-law.md"
+    source.write_text(
+        "## Overview\nContent.\n\n"
+        "## See also / انظر أيضًا\n"
+        "- `skills/labor-law-analysis.md` — §11\n"
+        "- `skills/compliance-check.md` — §11\n",
+        encoding="utf-8",
+    )
+    has_see_also, skills = vcr.parse_source(source)
+    assert has_see_also
+    assert skills == {"skills/labor-law-analysis.md", "skills/compliance-check.md"}
+
+def test_parse_source_with_see_also_markdown_link(tmp_path):
+    source = tmp_path / "labor-law.md"
+    source.write_text(
+        "## See also / انظر أيضًا\n"
+        "| [skills/contract-review.md](../skills/contract-review.md) | §11 |\n",
+        encoding="utf-8",
+    )
+    has_see_also, skills = vcr.parse_source(source)
+    assert has_see_also
+    assert "skills/contract-review.md" in skills
+
+
+# ── run_checks integration ─────────────────────────────────────────────────────
+
+def _write_skill(path: Path, name: str, sources: list) -> None:
+    rows = "\n".join(f"| reg | ref | desc | `{s}` |" for s in sources)
+    path.write_text(
+        f"## Introduction\nIntro.\n\n"
+        f"## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        f"{rows}\n"
+        f"راجع `sources/regulation-index.md` للصيغ الرسمية.\n\n"
+        f"## 12. Next\nOther.\n",
+        encoding="utf-8",
+    )
+
+def _write_source_with_see_also(path: Path, skills: list) -> None:
+    rows = "\n".join(
+        f"| [skills/{s}](../skills/{s}) | §11 | desc |"
+        for s in skills
+    )
+    path.write_text(
+        f"## Overview\nContent.\n\n---\n\n"
+        f"## See also / انظر أيضًا\n\n"
+        f"| Skill | Section | طبيعة الاستخدام |\n"
+        f"|-------|---------|----------------|\n"
+        f"{rows}\n",
+        encoding="utf-8",
+    )
+
+def _write_source_no_see_also(path: Path) -> None:
+    path.write_text("## Overview\nContent.\n", encoding="utf-8")
+
+
+def test_run_checks_passes_when_all_correct(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+
+    _write_skill(skills_dir / "labor-law-analysis.md", "labor-law-analysis", ["sources/labor-law.md"])
+    _write_source_with_see_also(sources_dir / "labor-law.md", ["labor-law-analysis.md"])
+    cross_ref.write_text(
+        "## 1b.\n`sources/labor-law.md` | `skills/labor-law-analysis.md`\n",
+        encoding="utf-8",
+    )
+
+    errors, warnings = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert errors == []
+    assert warnings == []
+
+
+def test_run_checks_check1_missing_see_also(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+
+    _write_skill(skills_dir / "labor-law-analysis.md", "labor-law-analysis", ["sources/labor-law.md"])
+    _write_source_no_see_also(sources_dir / "labor-law.md")
+
+    errors, _ = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert any("no '## See also'" in e for e in errors)
+
+
+def test_run_checks_check2_missing_reverse_link(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+
+    _write_skill(skills_dir / "compliance-check.md", "compliance-check", ["sources/labor-law.md"])
+    _write_source_with_see_also(sources_dir / "labor-law.md", ["labor-law-analysis.md"])
+
+    errors, _ = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert any("missing skills/compliance-check.md" in e for e in errors)
+
+
+def test_run_checks_check3_phantom_reference(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+
+    _write_skill(skills_dir / "legal-drafting.md", "legal-drafting", ["sources/pdpl.md"])
+    (sources_dir / "pdpl.md").write_text("## Overview\n", encoding="utf-8")
+    _write_source_with_see_also(sources_dir / "labor-law.md", ["legal-drafting.md"])
+
+    errors, _ = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert any("phantom" in e.lower() or "does not cite" in e for e in errors)
+
+
+def test_run_checks_check4_map_missing_row_is_warning(tmp_path):
+    skills_dir = tmp_path / "skills"
+    sources_dir = tmp_path / "sources"
+    skills_dir.mkdir()
+    sources_dir.mkdir()
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text("# Map\nNo rows yet.\n", encoding="utf-8")
+
+    _write_skill(skills_dir / "labor-law-analysis.md", "labor-law-analysis", ["sources/labor-law.md"])
+    _write_source_with_see_also(sources_dir / "labor-law.md", ["labor-law-analysis.md"])
+
+    errors, warnings = vcr.run_checks(skills_dir, sources_dir, cross_ref)
+    assert errors == []
+    assert any("cross-reference-map" in w for w in warnings)

--- a/tests/test_validate_cross_refs.py
+++ b/tests/test_validate_cross_refs.py
@@ -11,6 +11,38 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 import validate_cross_refs as vcr
 
 
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _write_skill(path: Path, name: str, sources: list) -> None:
+    rows = "\n".join(f"| reg | ref | desc | `{s}` |" for s in sources)
+    path.write_text(
+        f"## Introduction\nIntro.\n\n"
+        f"## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
+        f"{rows}\n"
+        f"راجع `sources/regulation-index.md` للصيغ الرسمية.\n\n"
+        f"## 12. Next\nOther.\n",
+        encoding="utf-8",
+    )
+
+def _write_source_with_see_also(path: Path, skill_names: list) -> None:
+    # skill_names: bare filenames only, e.g. "labor-law-analysis.md" (no "skills/" prefix)
+    rows = "\n".join(
+        f"| [skills/{s}](../skills/{s}) | §11 | desc |"
+        for s in skill_names
+    )
+    path.write_text(
+        f"## Overview\nContent.\n\n---\n\n"
+        f"## See also / انظر أيضًا\n\n"
+        f"| Skill | Section | طبيعة الاستخدام |\n"
+        f"|-------|---------|----------------|\n"
+        f"{rows}\n",
+        encoding="utf-8",
+    )
+
+def _write_source_no_see_also(path: Path) -> None:
+    path.write_text("## Overview\nContent.\n", encoding="utf-8")
+
+
 # ── Heading detection ──────────────────────────────────────────────────────────
 
 def test_normalize_heading_strips_hashes():
@@ -69,8 +101,10 @@ def test_extract_source_paths_deduplicates():
     assert vcr._extract_source_paths(text) == {"sources/labor-law.md"}
 
 def test_extract_source_paths_excludes_regulation_index():
-    text = "راجع `sources/regulation-index.md` للصيغ الرسمية"
-    assert "sources/regulation-index.md" not in vcr._extract_source_paths(text)
+    text = "راجع `sources/regulation-index.md` للصيغ الرسمية و`sources/labor-law.md`"
+    result = vcr._extract_source_paths(text)
+    assert "sources/regulation-index.md" not in result
+    assert "sources/labor-law.md" in result  # confirms regex still works
 
 def test_extract_skill_paths_backtick():
     text = "Implemented in `skills/contract-review.md`"
@@ -181,35 +215,6 @@ def test_parse_source_with_see_also_markdown_link(tmp_path):
 
 # ── run_checks integration ─────────────────────────────────────────────────────
 
-def _write_skill(path: Path, name: str, sources: list) -> None:
-    rows = "\n".join(f"| reg | ref | desc | `{s}` |" for s in sources)
-    path.write_text(
-        f"## Introduction\nIntro.\n\n"
-        f"## 11. Relevant Regulations / الأنظمة ذات الصلة\n"
-        f"{rows}\n"
-        f"راجع `sources/regulation-index.md` للصيغ الرسمية.\n\n"
-        f"## 12. Next\nOther.\n",
-        encoding="utf-8",
-    )
-
-def _write_source_with_see_also(path: Path, skills: list) -> None:
-    rows = "\n".join(
-        f"| [skills/{s}](../skills/{s}) | §11 | desc |"
-        for s in skills
-    )
-    path.write_text(
-        f"## Overview\nContent.\n\n---\n\n"
-        f"## See also / انظر أيضًا\n\n"
-        f"| Skill | Section | طبيعة الاستخدام |\n"
-        f"|-------|---------|----------------|\n"
-        f"{rows}\n",
-        encoding="utf-8",
-    )
-
-def _write_source_no_see_also(path: Path) -> None:
-    path.write_text("## Overview\nContent.\n", encoding="utf-8")
-
-
 def test_run_checks_passes_when_all_correct(tmp_path):
     skills_dir = tmp_path / "skills"
     sources_dir = tmp_path / "sources"
@@ -267,6 +272,8 @@ def test_run_checks_check3_phantom_reference(tmp_path):
     cross_ref = tmp_path / "cross-reference-map.md"
     cross_ref.write_text("", encoding="utf-8")
 
+    # legal-drafting.md cites sources/pdpl.md — NOT sources/labor-law.md.
+    # labor-law.md's See also lists legal-drafting.md anyway → phantom reference.
     _write_skill(skills_dir / "legal-drafting.md", "legal-drafting", ["sources/pdpl.md"])
     (sources_dir / "pdpl.md").write_text("## Overview\n", encoding="utf-8")
     _write_source_with_see_also(sources_dir / "labor-law.md", ["legal-drafting.md"])

--- a/tests/test_validate_cross_refs.py
+++ b/tests/test_validate_cross_refs.py
@@ -43,6 +43,12 @@ def test_is_see_also_heading_plain():
 def test_is_see_also_heading_unrelated():
     assert not vcr._is_see_also_heading("## Overview")
 
+def test_is_regulations_heading_arabic_alt():
+    assert vcr._is_regulations_heading("## الأنظمة ذات الصلة")
+
+def test_is_see_also_heading_arabic_only():
+    assert vcr._is_see_also_heading("## انظر أيضًا")
+
 
 # ── Path extraction ────────────────────────────────────────────────────────────
 

--- a/tests/test_validate_example_coverage.py
+++ b/tests/test_validate_example_coverage.py
@@ -194,6 +194,17 @@ def test_parse_skill_section_not_bleed_into_next(tmp_path):
     assert "examples/foo.md" in paths
     assert "examples/bar.md" not in paths
 
+def test_parse_skill_deduplicates_paths(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Related examples / أمثلة مرتبطة\n\n"
+        "* [examples/foo.md](../examples/foo.md) — ok\n"
+        "* [examples/foo.md](../examples/foo.md) — duplicate\n",
+        encoding="utf-8",
+    )
+    _, paths, _ = vec.parse_skill(skill)
+    assert len(paths) == 1
+
 
 # ── coverage_status ────────────────────────────────────────────────────────────
 

--- a/tests/test_validate_example_coverage.py
+++ b/tests/test_validate_example_coverage.py
@@ -219,3 +219,112 @@ def test_coverage_status_strong_two():
 
 def test_coverage_status_strong_many():
     assert vec.coverage_status(5) == "Strong"
+
+
+# ── run_checks integration ─────────────────────────────────────────────────────
+
+def _make_dirs(tmp_path):
+    skills_dir = tmp_path / "skills"
+    examples_dir = tmp_path / "examples"
+    skills_dir.mkdir()
+    examples_dir.mkdir()
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    return skills_dir, examples_dir, docs_dir
+
+
+def test_run_checks_passes_all_valid(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text(
+        "## Skill → Example Coverage\n"
+        "| `skills/labor-law-analysis.md` | 1 | ... | Partial |\n",
+        encoding="utf-8",
+    )
+    _write_example(examples_dir / "labor-dispute.md")
+    _write_skill_with_examples(
+        skills_dir / "labor-law-analysis.md",
+        ["examples/labor-dispute.md"],
+    )
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert errors == []
+    assert warnings == []
+
+
+def test_run_checks_check1_malformed_item_is_error(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    _write_skill_malformed_item(skills_dir / "skill.md")
+    errors, _ = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert any("malformed" in e for e in errors)
+
+
+def test_run_checks_check2_broken_path_is_error(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    _write_skill_with_examples(
+        skills_dir / "skill.md",
+        ["examples/does-not-exist.md"],
+    )
+    errors, _ = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert any("not found" in e for e in errors)
+
+
+def test_run_checks_check3_no_section_is_warning(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    _write_skill_no_section(skills_dir / "skill.md")
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert errors == []
+    assert any("no '## Related examples'" in w for w in warnings)
+
+
+def test_run_checks_check4_zero_examples_is_warning(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    (skills_dir / "skill.md").write_text(
+        "## Related examples / أمثلة مرتبطة\n\n## Next\n",
+        encoding="utf-8",
+    )
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert errors == []
+    assert any("0 valid examples" in w for w in warnings)
+
+
+def test_run_checks_check5_map_missing_row_is_warning(tmp_path):
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text(
+        "## Skill → Example Coverage\n| some-other-skill | ...\n",
+        encoding="utf-8",
+    )
+    _write_example(examples_dir / "example.md")
+    _write_skill_with_examples(skills_dir / "skill.md", ["examples/example.md"])
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert errors == []
+    assert any("cross-reference-map" in w for w in warnings)
+
+
+def test_run_checks_missing_skills_dir_is_error(tmp_path):
+    errors, _ = vec.run_checks(
+        tmp_path / "nonexistent-skills",
+        tmp_path / "examples",
+        tmp_path / "map.md",
+    )
+    assert any("not found" in e for e in errors)
+
+
+def test_run_checks_broken_path_does_not_suppress_warning_for_other_skills(tmp_path):
+    """Check 2 error in skill-a does not suppress Check 3 warning for skill-b."""
+    skills_dir, examples_dir, docs_dir = _make_dirs(tmp_path)
+    cross_ref = docs_dir / "cross-reference-map.md"
+    cross_ref.write_text("", encoding="utf-8")
+    _write_skill_with_examples(skills_dir / "skill-a.md", ["examples/missing.md"])
+    _write_skill_no_section(skills_dir / "skill-b.md")
+    errors, warnings = vec.run_checks(skills_dir, examples_dir, cross_ref)
+    assert any("missing.md" in e for e in errors)
+    assert any("skill-b.md" in w for w in warnings)

--- a/tests/test_validate_example_coverage.py
+++ b/tests/test_validate_example_coverage.py
@@ -1,0 +1,210 @@
+# tests/test_validate_example_coverage.py
+"""
+Tests for scripts/validate_example_coverage.py
+Saudi Legal AI Framework — skill→example coverage validator
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import validate_example_coverage as vec
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _write_skill_with_examples(path: Path, example_refs: list) -> None:
+    items = "\n".join(
+        f"* [{ref}](../{ref}) — description"
+        for ref in example_refs
+    )
+    path.write_text(
+        f"## Introduction\nIntro.\n\n"
+        f"## 11. Relevant Regulations\n\n"
+        f"## Related examples / أمثلة مرتبطة\n\n"
+        f"{items}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_no_section(path: Path) -> None:
+    path.write_text(
+        "## Introduction\nIntro.\n\n## 11. Relevant Regulations\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_malformed_item(path: Path) -> None:
+    path.write_text(
+        "## Related examples / أمثلة مرتبطة\n\n"
+        "* some description without a link\n",
+        encoding="utf-8",
+    )
+
+
+def _write_example(path: Path) -> None:
+    path.write_text("# Example\nContent.\n", encoding="utf-8")
+
+
+# ── Heading detection ──────────────────────────────────────────────────────────
+
+def test_normalize_heading_strips_hashes():
+    assert vec._normalize_heading("## Related examples") == "related examples"
+
+def test_normalize_heading_arabic():
+    assert vec._normalize_heading("## أمثلة مرتبطة") == "أمثلة مرتبطة"
+
+def test_normalize_heading_strips_section_number():
+    assert vec._normalize_heading("## 15. Related examples") == "related examples"
+
+def test_is_related_examples_heading_bilingual():
+    assert vec._is_related_examples_heading("## Related examples / أمثلة مرتبطة")
+
+def test_is_related_examples_heading_arabic_only():
+    assert vec._is_related_examples_heading("## أمثلة مرتبطة")
+
+def test_is_related_examples_heading_case_insensitive():
+    assert vec._is_related_examples_heading("## RELATED EXAMPLES")
+
+def test_is_related_examples_heading_with_section_number():
+    assert vec._is_related_examples_heading("## 15. Related examples")
+
+def test_is_related_examples_heading_unrelated():
+    assert not vec._is_related_examples_heading("## Introduction")
+
+def test_is_related_examples_heading_unrelated_arabic():
+    assert not vec._is_related_examples_heading("## الأنظمة ذات الصلة")
+
+
+# ── Path extraction ────────────────────────────────────────────────────────────
+
+def test_extract_example_paths_relative():
+    text = "* [examples/foo.md](../examples/foo.md) — description"
+    assert vec._extract_example_paths(text) == ["examples/foo.md"]
+
+def test_extract_example_paths_without_dotdot():
+    text = "* [foo](examples/foo.md) — description"
+    assert vec._extract_example_paths(text) == ["examples/foo.md"]
+
+def test_extract_example_paths_multiple():
+    text = (
+        "* [a](../examples/a.md) — desc\n"
+        "* [b](../examples/b.md) — desc\n"
+    )
+    result = vec._extract_example_paths(text)
+    assert "examples/a.md" in result
+    assert "examples/b.md" in result
+    assert len(result) == 2
+
+def test_extract_example_paths_ignores_non_examples():
+    text = "* [skills/foo.md](../skills/foo.md) — not an example"
+    assert vec._extract_example_paths(text) == []
+
+def test_extract_example_paths_empty_section():
+    assert vec._extract_example_paths("") == []
+
+
+# ── Malformed item detection ───────────────────────────────────────────────────
+
+def test_find_malformed_items_clean():
+    text = "* [examples/foo.md](../examples/foo.md) — description"
+    assert vec._find_malformed_items(text) == []
+
+def test_find_malformed_items_no_link():
+    text = "* some description without a link"
+    result = vec._find_malformed_items(text)
+    assert len(result) == 1
+    assert "some description without a link" in result[0]
+
+def test_find_malformed_items_dash_prefix():
+    text = "- some item without a link"
+    assert len(vec._find_malformed_items(text)) == 1
+
+def test_find_malformed_items_blank_lines_ok():
+    text = "\n\n* [examples/foo.md](../examples/foo.md) — ok\n\n"
+    assert vec._find_malformed_items(text) == []
+
+def test_find_malformed_items_non_list_lines_ok():
+    text = "Some intro text\n* [examples/foo.md](../examples/foo.md) — ok"
+    assert vec._find_malformed_items(text) == []
+
+def test_find_malformed_items_link_to_wrong_dir():
+    text = "* [sources/foo.md](../sources/foo.md) — wrong dir"
+    assert len(vec._find_malformed_items(text)) == 1
+
+
+# ── parse_skill ────────────────────────────────────────────────────────────────
+
+def test_parse_skill_with_valid_section(tmp_path):
+    skill = tmp_path / "labor-law-analysis.md"
+    _write_skill_with_examples(skill, ["examples/labor-dispute.md"])
+    has_section, paths, malformed = vec.parse_skill(skill)
+    assert has_section
+    assert "examples/labor-dispute.md" in paths
+    assert malformed == []
+
+def test_parse_skill_no_section(tmp_path):
+    skill = tmp_path / "skill.md"
+    _write_skill_no_section(skill)
+    has_section, paths, malformed = vec.parse_skill(skill)
+    assert not has_section
+    assert paths == []
+    assert malformed == []
+
+def test_parse_skill_malformed_item(tmp_path):
+    skill = tmp_path / "skill.md"
+    _write_skill_malformed_item(skill)
+    has_section, paths, malformed = vec.parse_skill(skill)
+    assert has_section
+    assert paths == []
+    assert len(malformed) == 1
+
+def test_parse_skill_arabic_heading(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## أمثلة مرتبطة\n\n"
+        "* [examples/foo.md](../examples/foo.md) — description\n",
+        encoding="utf-8",
+    )
+    has_section, paths, _ = vec.parse_skill(skill)
+    assert has_section
+    assert "examples/foo.md" in paths
+
+def test_parse_skill_empty_section(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Related examples / أمثلة مرتبطة\n\n## Next Section\n",
+        encoding="utf-8",
+    )
+    has_section, paths, malformed = vec.parse_skill(skill)
+    assert has_section
+    assert paths == []
+    assert malformed == []
+
+def test_parse_skill_section_not_bleed_into_next(tmp_path):
+    skill = tmp_path / "skill.md"
+    skill.write_text(
+        "## Related examples / أمثلة مرتبطة\n\n"
+        "* [examples/foo.md](../examples/foo.md) — ok\n\n"
+        "## Next Section\n"
+        "* [examples/bar.md](../examples/bar.md) — should not appear\n",
+        encoding="utf-8",
+    )
+    _, paths, _ = vec.parse_skill(skill)
+    assert "examples/foo.md" in paths
+    assert "examples/bar.md" not in paths
+
+
+# ── coverage_status ────────────────────────────────────────────────────────────
+
+def test_coverage_status_missing():
+    assert vec.coverage_status(0) == "Missing"
+
+def test_coverage_status_partial():
+    assert vec.coverage_status(1) == "Partial"
+
+def test_coverage_status_strong_two():
+    assert vec.coverage_status(2) == "Strong"
+
+def test_coverage_status_strong_many():
+    assert vec.coverage_status(5) == "Strong"

--- a/tests/test_validate_skill_graph.py
+++ b/tests/test_validate_skill_graph.py
@@ -126,6 +126,16 @@ def test_extract_skill_edges_missing_relationship_line_skips_entry():
     assert vsg._extract_skill_edges(section) == []
 
 
+def test_extract_skill_edges_invalid_relationship_token_rejected():
+    # A token with trailing punctuation is not a valid relationship type
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: escalates_to.\n"
+        "  — some rationale\n"
+    )
+    assert vsg._extract_skill_edges(section) == []
+
+
 # ── Malformed entry detection ─────────────────────────────────────────────────────
 
 def test_find_malformed_entries_clean_returns_empty():

--- a/tests/test_validate_skill_graph.py
+++ b/tests/test_validate_skill_graph.py
@@ -203,3 +203,155 @@ def test_parse_skill_arabic_heading(tmp_path):
     has_section, edges, _ = vsg.parse_skill(f)
     assert has_section
     assert len(edges) == 1
+
+
+# ── graph_stats ──────────────────────────────────────────────────────────────────
+
+def test_graph_stats_basic():
+    graph = {
+        "skills/a.md": [Edge(target="skills/b.md", relationship="escalates_to", rationale="r")],
+        "skills/b.md": [Edge(target="skills/a.md", relationship="alternative_to", rationale="r")],
+    }
+    stats = vsg.graph_stats(graph)
+    assert stats["nodes"] == 2
+    assert stats["edges"] == 2
+    assert stats["orphans"] == []
+    assert stats["components"] == 1
+
+
+def test_graph_stats_orphan_detected():
+    graph = {
+        "skills/a.md": [Edge(target="skills/b.md", relationship="escalates_to", rationale="r")],
+        "skills/b.md": [],
+        "skills/c.md": [],  # c has no in-edges and no out-edges → orphan
+    }
+    stats = vsg.graph_stats(graph)
+    assert "skills/c.md" in stats["orphans"]
+    assert "skills/b.md" not in stats["orphans"]  # b has in-edge from a
+
+
+# ── run_checks integration ────────────────────────────────────────────────────────
+
+def test_run_checks_passes_all_valid(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    a = skills_dir / "a.md"
+    b = skills_dir / "b.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "a leads to b")])
+    _write_skill_with_edges(b, [("skills/a.md", "alternative_to", "b is alternative to a")])
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text(
+        "## Skill Relationship Graph\n\n| `skills/a.md` |\n| `skills/b.md` |\n",
+        encoding="utf-8",
+    )
+    errors, warnings, stats = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert stats["nodes"] == 2
+    assert stats["edges"] == 2
+
+
+def test_run_checks_e1_missing_skills_dir(tmp_path):
+    errors, warnings, stats = vsg.run_checks(
+        skills_dir=tmp_path / "nonexistent",
+        cross_ref_map=tmp_path / "map.md",
+    )
+    assert any("not found" in e for e in errors)
+    assert stats == {}
+
+
+def test_run_checks_e2_broken_path(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "a.md"
+    _write_skill_with_edges(skill, [("skills/missing.md", "escalates_to", "does not exist")])
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("not found" in e for e in errors)
+
+
+def test_run_checks_e3_invalid_type(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    b = skills_dir / "b.md"
+    _write_skill_no_section(b)
+    a = skills_dir / "a.md"
+    a.write_text(
+        "## Related skills / مهارات مرتبطة\n\n"
+        "* [b.md](../skills/b.md)\n"
+        "  — relationship: invented_type\n"
+        "  — some rationale\n",
+        encoding="utf-8",
+    )
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("unknown relationship type" in e for e in errors)
+
+
+def test_run_checks_e4_malformed_entry(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _write_skill_malformed_item(skills_dir / "a.md")
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("malformed entry" in e for e in errors)
+
+
+def test_run_checks_e5_self_reference(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "a.md"
+    _write_skill_with_edges(skill, [("skills/a.md", "depends_on", "itself")])
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("self-reference" in e for e in errors)
+
+
+def test_run_checks_w1_no_section(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _write_skill_no_section(skills_dir / "a.md")
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert any("no '## Related skills' section" in w for w in warnings)
+
+
+def test_run_checks_w2_orphan(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    a, b, c = skills_dir / "a.md", skills_dir / "b.md", skills_dir / "c.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "a leads to b")])
+    _write_skill_with_edges(b, [("skills/a.md", "alternative_to", "b to a")])
+    # c has a section but no valid entries → orphan
+    c.write_text(
+        "## Related skills / مهارات مرتبطة\n\n(no entries yet)\n",
+        encoding="utf-8",
+    )
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text(
+        "## Skill Relationship Graph\n"
+        "| `skills/a.md` |\n| `skills/b.md` |\n| `skills/c.md` |\n",
+        encoding="utf-8",
+    )
+    errors, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert any("orphan" in w for w in warnings)
+
+
+def test_run_checks_w4_map_drift(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    b = skills_dir / "b.md"
+    _write_skill_no_section(b)
+    a = skills_dir / "a.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "rationale")])
+    # cross_ref map exists but has no Skill Relationship Graph section
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Some Other Section\n", encoding="utf-8")
+    _, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("Skill Relationship Graph" in w for w in warnings)

--- a/tests/test_validate_skill_graph.py
+++ b/tests/test_validate_skill_graph.py
@@ -355,3 +355,21 @@ def test_run_checks_w4_map_drift(tmp_path):
     cross_ref.write_text("## Some Other Section\n", encoding="utf-8")
     _, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
     assert any("Skill Relationship Graph" in w for w in warnings)
+
+
+def test_run_checks_w3_asymmetric(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    a = skills_dir / "a.md"
+    b = skills_dir / "b.md"
+    # a → b (escalates_to), no reverse edge from b → a
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "a leads to b")])
+    _write_skill_with_edges(b, [])  # b has section but no out-edges
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text(
+        "## Skill Relationship Graph\n| `skills/a.md` |\n| `skills/b.md` |\n",
+        encoding="utf-8",
+    )
+    errors, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert any("asymmetric" in w for w in warnings)

--- a/tests/test_validate_skill_graph.py
+++ b/tests/test_validate_skill_graph.py
@@ -1,0 +1,195 @@
+# tests/test_validate_skill_graph.py
+"""Tests for scripts/validate_skill_graph.py — Saudi Legal AI Framework"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import validate_skill_graph as vsg
+from validate_skill_graph import Edge
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────────
+
+def _write_skill_with_edges(path: Path, edges: list) -> None:
+    """Write a skill file with a properly-formed Related skills section.
+
+    edges: list of (target_path, relationship_type, rationale) tuples
+           e.g. ("skills/foo.md", "escalates_to", "some reason")
+    """
+    items = []
+    for target, rel_type, rationale in edges:
+        items.append(
+            f"* [{target}](../{target})\n"
+            f"  — relationship: {rel_type}\n"
+            f"  — {rationale}"
+        )
+    body = "\n\n".join(items)
+    path.write_text(
+        "## Introduction\nIntro.\n\n"
+        "## Related skills / مهارات مرتبطة\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_no_section(path: Path) -> None:
+    path.write_text(
+        "## Introduction\nIntro.\n\n## 11. Relevant Regulations\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_malformed_item(path: Path) -> None:
+    path.write_text(
+        "## Related skills / مهارات مرتبطة\n\n"
+        "* some description without a link\n",
+        encoding="utf-8",
+    )
+
+
+# ── Heading detection ────────────────────────────────────────────────────────────
+
+def test_normalize_heading_strips_hashes():
+    assert vsg._normalize_heading("## Related skills") == "related skills"
+
+def test_normalize_heading_arabic():
+    assert vsg._normalize_heading("## مهارات مرتبطة") == "مهارات مرتبطة"
+
+def test_normalize_heading_strips_section_number():
+    assert vsg._normalize_heading("## 15. Related skills") == "related skills"
+
+def test_is_related_skills_heading_bilingual():
+    assert vsg._is_related_skills_heading("## Related skills / مهارات مرتبطة")
+
+def test_is_related_skills_heading_arabic_only():
+    assert vsg._is_related_skills_heading("## مهارات مرتبطة")
+
+def test_is_related_skills_heading_case_insensitive():
+    assert vsg._is_related_skills_heading("## RELATED SKILLS")
+
+def test_is_related_skills_heading_unrelated():
+    assert not vsg._is_related_skills_heading("## Related examples")
+
+def test_is_related_skills_heading_unrelated_arabic():
+    assert not vsg._is_related_skills_heading("## الأنظمة ذات الصلة")
+
+
+# ── Edge extraction ──────────────────────────────────────────────────────────────
+
+VALID_EDGE_SECTION = (
+    "* [commercial-dispute.md](../skills/commercial-dispute.md)\n"
+    "  — relationship: escalates_to\n"
+    "  — a contract dispute may require Commercial Court proceedings\n"
+)
+
+def test_extract_skill_edges_single_valid_edge():
+    edges = vsg._extract_skill_edges(VALID_EDGE_SECTION)
+    assert len(edges) == 1
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert edges[0].relationship == "escalates_to"
+    assert "contract dispute" in edges[0].rationale
+
+def test_extract_skill_edges_multiple_edges():
+    section = (
+        "* [commercial-dispute.md](../skills/commercial-dispute.md)\n"
+        "  — relationship: escalates_to\n"
+        "  — breach may lead to litigation\n"
+        "\n"
+        "* [arbitration.md](../skills/arbitration.md)\n"
+        "  — relationship: escalates_to\n"
+        "  — arbitration clause may activate this path\n"
+    )
+    edges = vsg._extract_skill_edges(section)
+    assert len(edges) == 2
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert edges[1].target == "skills/arbitration.md"
+
+def test_extract_skill_edges_normalizes_dotdot_prefix():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: depends_on\n"
+        "  — rationale\n"
+    )
+    edges = vsg._extract_skill_edges(section)
+    assert edges[0].target == "skills/foo.md"
+
+def test_extract_skill_edges_no_links_returns_empty():
+    assert vsg._extract_skill_edges("no links here\n* plain bullet\n") == []
+
+def test_extract_skill_edges_missing_relationship_line_skips_entry():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  just some text without relationship:\n"
+        "  — rationale\n"
+    )
+    assert vsg._extract_skill_edges(section) == []
+
+
+# ── Malformed entry detection ─────────────────────────────────────────────────────
+
+def test_find_malformed_entries_clean_returns_empty():
+    assert vsg._find_malformed_entries(VALID_EDGE_SECTION) == []
+
+def test_find_malformed_entries_no_link():
+    section = "* some text without a skills link\n"
+    result = vsg._find_malformed_entries(section)
+    assert len(result) == 1
+    assert "some text" in result[0]
+
+def test_find_malformed_entries_missing_relationship_line():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — just rationale without relationship line\n"
+    )
+    assert len(vsg._find_malformed_entries(section)) == 1
+
+def test_find_malformed_entries_missing_rationale_line():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: escalates_to\n"
+    )
+    assert len(vsg._find_malformed_entries(section)) == 1
+
+
+# ── parse_skill ──────────────────────────────────────────────────────────────────
+
+def test_parse_skill_with_valid_section(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_with_edges(f, [
+        ("skills/commercial-dispute.md", "escalates_to", "breach may lead to litigation"),
+    ])
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert has_section
+    assert len(edges) == 1
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert malformed == []
+
+def test_parse_skill_no_section(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_no_section(f)
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert not has_section
+    assert edges == []
+    assert malformed == []
+
+def test_parse_skill_malformed_entry(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_malformed_item(f)
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert has_section
+    assert edges == []
+    assert len(malformed) == 1
+
+def test_parse_skill_arabic_heading(tmp_path):
+    f = tmp_path / "myskill.md"
+    f.write_text(
+        "## مهارات مرتبطة\n\n"
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: depends_on\n"
+        "  — rationale text\n",
+        encoding="utf-8",
+    )
+    has_section, edges, _ = vsg.parse_skill(f)
+    assert has_section
+    assert len(edges) == 1


### PR DESCRIPTION
## Summary

- Adds `## Related skills / مهارات مرتبطة` sections to all 7 `skills/*.md` files, forming a 15-edge typed directed graph using 8 allowed relationship types (`escalates_to`, `alternative_to`, `cross_checks`, `depends_on`, `specializes`, `precedes`, `shares_sources_with`, `overlaps_with`)
- Adds `scripts/validate_skill_graph.py` — parses edge structure, validates paths and relationship types, detects malformed entries, self-references, and orphans; emits graph stats on every CI run (exit 1 on errors, exit 0 on warnings-only)
- Adds `## Skill Relationship Graph` reference table to `docs/cross-reference-map.md`
- Wires `validate_skill_graph.py` into CI after `validate_example_coverage.py`

## Graph snapshot

```
Nodes: 7  |  Edges: 15  |  Components: 1  |  Orphans: none
Most connected: contract-review.md (degree 8)
Types: depends_on×4  cross_checks×4  alternative_to×2  precedes×2  escalates_to×2  specializes×1
```

~7 W3 asymmetric warnings fire on clean runs for intentionally one-directional edges (`escalates_to`, `specializes`, one-way `precedes`) — informational, non-blocking.

Export flags (JSON/DOT/Mermaid) are **not** included — deferred to a follow-up PR after the graph is stable.

## Test Plan

- [x] `python3 -m pytest tests/ -q` — 152 passed, 0 failed
- [x] `python3 scripts/validate_skill_graph.py` — exit 0, 0 errors, ~7 W3 warnings
- [x] `python3 scripts/validate_cross_refs.py && python3 scripts/validate_example_coverage.py && python3 scripts/validate_skill_graph.py` — all three exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)