### PR TITLE
feat: add typed skill relationship graph (14-edge validator)

### DIFF
--- a/.github/workflows/validate-datasets.yml
+++ b/.github/workflows/validate-datasets.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Validate example coverage
         run: python3 scripts/validate_example_coverage.py
 
+      - name: Validate skill graph
+        run: python3 scripts/validate_skill_graph.py
 
       - name: Validate main dataset
         run: python3 scripts/validate_dataset.py

--- a/docs/cross-reference-map.md
+++ b/docs/cross-reference-map.md
@@ -114,6 +114,27 @@ This map shows the relationships between project files. The goal: every contribu
 
 ---
 
+## Skill Relationship Graph
+
+> هذا الجدول مُولَّد من `## Related skills` في كل ملف `skills/*.md`.
+> يُشغَّل `scripts/validate_skill_graph.py` في كل push للتحقق منه.
+> This table is derived from `## Related skills` in each `skills/*.md` file.
+> `scripts/validate_skill_graph.py` runs on every push to verify it.
+
+| Skill | Related Skills | Relationship Types | Graph Degree | Connectivity Status |
+|---|---|---|---|---|
+| `skills/arbitration.md` | `skills/commercial-dispute.md` · `skills/legal-drafting.md` | `alternative_to` · `depends_on` | 4 (2 out, 2 in) | Connected |
+| `skills/commercial-dispute.md` | `skills/arbitration.md` · `skills/legal-drafting.md` | `alternative_to` · `precedes` | 4 (2 out, 2 in) | Connected |
+| `skills/compliance-check.md` | `skills/labor-law-analysis.md` | `cross_checks` | 4 (1 out, 3 in) | Connected |
+| `skills/contract-review.md` | `skills/commercial-dispute.md` · `skills/arbitration.md` · `skills/legal-drafting.md` · `skills/compliance-check.md` | `escalates_to` · `precedes` · `cross_checks` | 7 (4 out, 3 in) | Connected |
+| `skills/labor-law-analysis.md` | `skills/compliance-check.md` · `skills/contract-review.md` | `cross_checks` · `depends_on` | 3 (2 out, 1 in) | Connected |
+| `skills/legal-drafting.md` | `skills/contract-review.md` | `depends_on` | 4 (1 out, 3 in) | Connected |
+| `skills/real-estate-contracts.md` | `skills/contract-review.md` · `skills/compliance-check.md` | `specializes` · `depends_on` | 2 (2 out, 0 in) | Connected |
+
+**Allowed relationship types:** `escalates_to` · `alternative_to` · `cross_checks` · `depends_on` · `specializes` · `precedes` · `shares_sources_with` · `overlaps_with`
+
+---
+
 ## 4. Sources ← → Regulations / المصادر ← → الأنظمة
 
 | Source File | Regulation | Royal Decree | صيغة الاستشهاد الرسمية |

--- a/scripts/validate_skill_graph.py
+++ b/scripts/validate_skill_graph.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+validate_skill_graph.py
+Saudi Legal AI Framework — typed skill relationship graph validator
+
+Checks that every skills/*.md file has a ## Related skills section with
+well-formed, typed edges pointing to existing skills.
+
+Exit codes: 0 = pass (or warnings only), 1 = errors found
+"""
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+CROSS_REF_MAP = REPO_ROOT / "docs" / "cross-reference-map.md"
+
+RELATED_SKILLS_HEADING_ALIASES = [
+    "related skills",
+    "مهارات مرتبطة",
+]
+
+ALLOWED_RELATIONSHIP_TYPES = {
+    "escalates_to",
+    "alternative_to",
+    "cross_checks",
+    "depends_on",
+    "specializes",
+    "precedes",
+    "shares_sources_with",
+    "overlaps_with",
+}
+
+
+@dataclass(frozen=True)
+class Edge:
+    target: str        # normalized: "skills/foo.md"
+    relationship: str  # must be in ALLOWED_RELATIONSHIP_TYPES
+    rationale: str     # free text description
+
+
+def _normalize_heading(line: str) -> str:
+    """Strip leading #, section numbers (e.g. 11., §11), and lowercase."""
+    text = re.sub(r"^#+\s*", "", line)
+    text = re.sub(r"^\d+\.\s*", "", text)
+    text = re.sub(r"§\d+\s*", "", text)
+    return text.strip().lower()
+
+
+def _is_related_skills_heading(line: str) -> bool:
+    normalized = _normalize_heading(line)
+    return any(alias in normalized for alias in RELATED_SKILLS_HEADING_ALIASES)
+
+
+def _heading_level(line: str) -> int:
+    m = re.match(r"^(#+)", line)
+    return len(m.group(1)) if m else 0
+
+
+def _extract_section(lines: list, heading_predicate) -> str:
+    """Return the text body of the first section matching heading_predicate."""
+    in_section = False
+    section_level = 0
+    body: list = []
+    for line in lines:
+        if not in_section:
+            if line.startswith("#") and heading_predicate(line):
+                in_section = True
+                section_level = _heading_level(line)
+        else:
+            lvl = _heading_level(line)
+            if line.startswith("#") and lvl <= section_level:
+                break
+            body.append(line)
+    return "\n".join(body)
+
+
+def _has_section_heading(lines: list, heading_predicate) -> bool:
+    """Return True if any line is a heading matching heading_predicate."""
+    return any(
+        line.startswith("#") and heading_predicate(line)
+        for line in lines
+    )
+
+
+def _extract_skill_edges(section_text: str) -> list:
+    """
+    Parse 3-line edge blocks from a ## Related skills section body.
+
+    Expected format per edge:
+        * [label](../skills/foo.md)
+          — relationship: escalates_to
+          — rationale text
+
+    Returns only structurally valid blocks. Malformed blocks are reported
+    separately by _find_malformed_entries and validated in run_checks.
+    """
+    lines = [ln.rstrip() for ln in section_text.splitlines()]
+    edges = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith(("* ", "- ")):
+            m = re.search(
+                r'\[([^\]]*)\]\((?:\.\./)?(skills/[\w.-]+\.md)\)',
+                stripped,
+            )
+            if m:
+                target = m.group(2)
+                j = i + 1
+                while j < len(lines) and not lines[j].strip():
+                    j += 1
+                if j < len(lines):
+                    rel_m = re.match(
+                        r'^\s*[—\-]\s*relationship:\s*([A-Za-z_]+)\s*$',
+                        lines[j],
+                    )
+                    if rel_m:
+                        relationship = rel_m.group(1)
+                        k = j + 1
+                        while k < len(lines) and not lines[k].strip():
+                            k += 1
+                        if k < len(lines):
+                            rat_m = re.match(
+                                r'^\s*[—\-]\s*(.+)',
+                                lines[k],
+                            )
+                            if rat_m:
+                                edges.append(
+                                    Edge(
+                                        target=target,
+                                        relationship=relationship,
+                                        rationale=rat_m.group(1).strip(),
+                                    )
+                                )
+        i += 1
+    return edges
+
+
+def _find_malformed_entries(section_text: str) -> list:
+    """
+    Return bullet lines that are structurally malformed:
+    - Bullet with no link to skills/
+    - Bullet with skills/ link but missing — relationship: line
+    - Bullet with skills/ link and relationship: but missing rationale line
+    """
+    lines = [ln.rstrip() for ln in section_text.splitlines()]
+    malformed = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith(("* ", "- ")):
+            m = re.search(
+                r'\[([^\]]*)\]\((?:\.\./)?(skills/[\w.-]+\.md)\)',
+                stripped,
+            )
+            if not m:
+                malformed.append(stripped)
+                i += 1
+                continue
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                j += 1
+            if j >= len(lines) or not re.match(
+                r'^\s*[—\-]\s*relationship:\s*[A-Za-z_]+', lines[j]
+            ):
+                malformed.append(stripped)
+                i += 1
+                continue
+            k = j + 1
+            while k < len(lines) and not lines[k].strip():
+                k += 1
+            if k >= len(lines) or not re.match(r'^\s*[—\-]\s*.+', lines[k]):
+                malformed.append(stripped)
+        i += 1
+    return malformed
+
+
+def parse_skill(path: Path) -> tuple:
+    """
+    Parse a skill file for its Related skills section.
+
+    Returns (has_section, edges, malformed_entries):
+    - has_section: True if ## Related skills heading found
+    - edges: list of Edge (structurally valid blocks only)
+    - malformed_entries: list of malformed bullet line strings
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    has_section = _has_section_heading(lines, _is_related_skills_heading)
+    if not has_section:
+        return False, [], []
+    section_text = _extract_section(lines, _is_related_skills_heading)
+    return (
+        True,
+        _extract_skill_edges(section_text),
+        _find_malformed_entries(section_text),
+    )

--- a/scripts/validate_skill_graph.py
+++ b/scripts/validate_skill_graph.py
@@ -198,3 +198,216 @@ def parse_skill(path: Path) -> tuple:
         _extract_skill_edges(section_text),
         _find_malformed_entries(section_text),
     )
+
+
+def _count_components(all_nodes: set, graph: dict) -> int:
+    """Count weakly connected components (treating edges as undirected)."""
+    adjacency: dict = {n: set() for n in all_nodes}
+    for src, edges in graph.items():
+        for e in edges:
+            adjacency.setdefault(src, set()).add(e.target)
+            adjacency.setdefault(e.target, set()).add(src)
+
+    visited: set = set()
+    components = 0
+    for start in all_nodes:
+        if start not in visited:
+            components += 1
+            queue = [start]
+            while queue:
+                node = queue.pop()
+                if node in visited:
+                    continue
+                visited.add(node)
+                queue.extend(adjacency.get(node, set()) - visited)
+    return components
+
+
+def graph_stats(graph: dict) -> dict:
+    """
+    Compute summary statistics for the skill graph.
+
+    graph: dict mapping "skills/source.md" -> list[Edge]
+    Returns a dict with keys: nodes, edges, orphans, most_connected,
+    type_counts, components.
+    """
+    all_nodes: set = set(graph.keys())
+    for edges in graph.values():
+        for e in edges:
+            all_nodes.add(e.target)
+
+    out_degree = {n: len(graph.get(n, [])) for n in all_nodes}
+    in_degree: dict = {n: 0 for n in all_nodes}
+    for edges in graph.values():
+        for e in edges:
+            in_degree[e.target] = in_degree.get(e.target, 0) + 1
+
+    total_degree = {n: out_degree.get(n, 0) + in_degree.get(n, 0) for n in all_nodes}
+    orphans = sorted(n for n in all_nodes if total_degree[n] == 0)
+    most_connected = sorted(all_nodes, key=lambda n: total_degree[n], reverse=True)
+
+    type_counts: dict = {}
+    total_edges = 0
+    for edges in graph.values():
+        for e in edges:
+            type_counts[e.relationship] = type_counts.get(e.relationship, 0) + 1
+            total_edges += 1
+
+    return {
+        "nodes": len(all_nodes),
+        "edges": total_edges,
+        "orphans": orphans,
+        "most_connected": most_connected[:3],
+        "type_counts": type_counts,
+        "components": _count_components(all_nodes, graph) if all_nodes else 0,
+    }
+
+
+def format_stats(stats: dict) -> str:
+    """Format graph statistics for stdout display."""
+    type_str = "  ".join(
+        f"{t}\xd7{c}"
+        for t, c in sorted(stats["type_counts"].items(), key=lambda x: -x[1])
+    ) or "(none)"
+    most_conn = ", ".join(stats["most_connected"]) if stats["most_connected"] else "—"
+    orphan_str = ", ".join(stats["orphans"]) if stats["orphans"] else "none"
+    return "\n".join([
+        "── Skill Graph Summary ─────────────────────────────",
+        f"  Nodes (skills):        {stats['nodes']}",
+        f"  Edges (relationships): {stats['edges']}",
+        f"  Orphan skills:         {orphan_str}",
+        f"  Most connected:        {most_conn}",
+        f"  Relationship types:    {type_str}",
+        f"  Connectivity:          {stats['components']} component(s)",
+        "─" * 49,
+    ])
+
+
+def run_checks(
+    skills_dir: Path = SKILLS_DIR,
+    cross_ref_map: Path = CROSS_REF_MAP,
+) -> tuple:
+    """
+    Run all validation checks. Returns (errors, warnings, stats).
+
+    Errors (CI-blocking, exit 1):
+      E1: required skills/ directory missing
+      E2: referenced skill file does not exist on disk
+      E3: invalid relationship type
+      E4: malformed entry structure
+      E5: self-reference
+
+    Warnings (non-blocking, exit 0):
+      W1: skill has no ## Related skills section
+      W2: orphan skill (0 in-edges and 0 out-edges across full graph)
+      W3: asymmetric relationship (informational)
+      W4: cross-reference-map missing Skill Relationship Graph row
+    """
+    errors: list = []
+    warnings: list = []
+
+    if not skills_dir.exists():
+        errors.append(f"ERROR: required directory not found: {skills_dir}")
+        return errors, warnings, {}
+
+    map_text = cross_ref_map.read_text(encoding="utf-8") if cross_ref_map.exists() else ""
+
+    graph: dict = {}
+
+    for skill_file in sorted(skills_dir.glob("*.md")):
+        skill_path = f"skills/{skill_file.name}"
+        has_section, edges, malformed = parse_skill(skill_file)
+
+        # W1: No section
+        if not has_section:
+            warnings.append(
+                f"WARNING: {skill_path} has no '## Related skills' section."
+            )
+            graph[skill_path] = []
+            continue
+
+        graph[skill_path] = []
+
+        # E4: Malformed entries
+        for item in malformed:
+            errors.append(
+                f"ERROR: {skill_path} 'Related skills': malformed entry: {item!r}"
+            )
+
+        for edge in edges:
+            # E5: Self-reference
+            if edge.target == skill_path:
+                errors.append(
+                    f"ERROR: {skill_path} has a self-reference in 'Related skills'."
+                )
+                continue
+
+            # E2: Broken path
+            if not (skills_dir.parent / edge.target).exists():
+                errors.append(
+                    f"ERROR: {skill_path} references {edge.target!r} but file not found."
+                )
+                continue
+
+            # E3: Invalid relationship type
+            if edge.relationship not in ALLOWED_RELATIONSHIP_TYPES:
+                errors.append(
+                    f"ERROR: {skill_path} uses unknown relationship type "
+                    f"{edge.relationship!r} (→ {edge.target})."
+                )
+                continue
+
+            graph[skill_path].append(edge)
+
+        # W4: Map drift
+        row_present = (skill_path in map_text) and ("Skill Relationship Graph" in map_text)
+        if not row_present:
+            warnings.append(
+                f"WARNING: cross-reference-map.md 'Skill Relationship Graph' "
+                f"may be missing row for {skill_path}."
+            )
+
+    # Compute stats over full graph
+    stats = graph_stats(graph)
+
+    # W2: Orphan skills
+    for orphan in stats["orphans"]:
+        warnings.append(
+            f"WARNING: {orphan} appears to be an orphan (0 in-edges and 0 out-edges)."
+        )
+
+    # W3: Asymmetric relationships (informational)
+    for src, src_edges in graph.items():
+        for e in src_edges:
+            target_edges = graph.get(e.target, [])
+            reverse_exists = any(te.target == src for te in target_edges)
+            if not reverse_exists:
+                warnings.append(
+                    f"WARNING: asymmetric — {src} → {e.target} "
+                    f"({e.relationship}) has no reverse edge."
+                )
+
+    return errors, warnings, stats
+
+
+def main() -> None:
+    errors, warnings, stats = run_checks()
+
+    if stats:
+        print(format_stats(stats))
+
+    for w in warnings:
+        print(w)
+    for e in errors:
+        print(e)
+
+    if not errors and not warnings:
+        print("✓ All skill graph checks passed.")
+    elif not errors:
+        print("✓ No errors. See warnings above.")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/arbitration.md
+++ b/skills/arbitration.md
@@ -403,6 +403,18 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [commercial-dispute.md](../skills/commercial-dispute.md)
+  — relationship: alternative_to
+  — Commercial Court litigation is the fallback when arbitration is excluded, waived, or fails
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: depends_on
+  — arbitration requests, submissions, and award enforcement filings require legal drafting
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/arbitration-example.md](../examples/arbitration-example.md) — cross-border supply dispute: enforcing a DIAC arbitration clause under Saudi law

--- a/skills/commercial-dispute.md
+++ b/skills/commercial-dispute.md
@@ -415,6 +415,18 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [arbitration.md](../skills/arbitration.md)
+  — relationship: alternative_to
+  — arbitration replaces court litigation when a valid arbitration clause exists or parties agree
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: precedes
+  — formal demand notices must be drafted before court filing
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/commercial-dispute-example.md](../examples/commercial-dispute-example.md) — commercial dispute analysis under Saudi commercial courts framework

--- a/skills/compliance-check.md
+++ b/skills/compliance-check.md
@@ -394,6 +394,14 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [labor-law-analysis.md](../skills/labor-law-analysis.md)
+  — relationship: cross_checks
+  — Nitaqat (Saudization), WPS, and GOSI compliance are labor law sub-domains that require cross-verification
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/compliance-example.md](../examples/compliance-example.md) — SaaS startup compliance assessment (PDPL, Nitaqat, WPS)

--- a/skills/contract-review.md
+++ b/skills/contract-review.md
@@ -453,6 +453,26 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [commercial-dispute.md](../skills/commercial-dispute.md)
+  — relationship: escalates_to
+  — unresolved contract breach or contested clause may require Commercial Court proceedings
+
+* [arbitration.md](../skills/arbitration.md)
+  — relationship: escalates_to
+  — an arbitration clause in the contract activates this path instead of court litigation
+
+* [legal-drafting.md](../skills/legal-drafting.md)
+  — relationship: precedes
+  — review identifies gaps and red flags; legal-drafting is then used to address them
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: cross_checks
+  — contracts containing PDPL clauses, Nitaqat obligations, or WPS terms need compliance verification
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/contract-review-example.md](../examples/contract-review-example.md) — professional services contract review: foreign governing law clause, interest, IP transfer

--- a/skills/labor-law-analysis.md
+++ b/skills/labor-law-analysis.md
@@ -412,6 +412,18 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: cross_checks
+  — employment compliance dimensions (PDPL over HR data, Saudization quotas) cross both domains
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: depends_on
+  — employment contracts are analysed using the contract-review methodology for clause-level risk
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/employment-contract-review.md](../examples/employment-contract-review.md) — employment contract review: mandatory elements check under Saudi Labour Law

--- a/skills/legal-drafting.md
+++ b/skills/legal-drafting.md
@@ -404,6 +404,14 @@ What automated drafting cannot guarantee:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: depends_on
+  — quality criteria for drafted documents are grounded in contract-review red flags and mandatory clause checklists
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/legal-drafting-example.md](../examples/legal-drafting-example.md) — software services contract drafting: milestone-linked payments, IP, PDPL clauses

--- a/skills/real-estate-contracts.md
+++ b/skills/real-estate-contracts.md
@@ -407,6 +407,18 @@ What AI cannot assess in this context:
 
 ---
 
+## Related skills / مهارات مرتبطة
+
+* [contract-review.md](../skills/contract-review.md)
+  — relationship: specializes
+  — real estate contracts are a domain-scoped application of the general contract review methodology
+
+* [compliance-check.md](../skills/compliance-check.md)
+  — relationship: depends_on
+  — Ejar registration, municipal approvals, and REGA requirements are compliance obligations
+
+---
+
 ## Related examples / أمثلة مرتبطة
 
 * [examples/commercial-lease-exit-example.md](../examples/commercial-lease-exit-example.md) — early exit from commercial lease: penalty clause enforceability

--- a/tests/test_validate_skill_graph.py
+++ b/tests/test_validate_skill_graph.py
@@ -195,3 +195,146 @@ def test_parse_skill_arabic_heading(tmp_path):
     has_section, edges, _ = vsg.parse_skill(f)
     assert has_section
     assert len(edges) == 1
+
+
+# ── graph_stats ──────────────────────────────────────────────────────────────────
+
+def test_graph_stats_basic():
+    graph = {
+        "skills/a.md": [Edge(target="skills/b.md", relationship="escalates_to", rationale="r")],
+        "skills/b.md": [Edge(target="skills/a.md", relationship="alternative_to", rationale="r")],
+    }
+    stats = vsg.graph_stats(graph)
+    assert stats["nodes"] == 2
+    assert stats["edges"] == 2
+    assert stats["orphans"] == []
+    assert stats["components"] == 1
+
+def test_graph_stats_orphan_detected():
+    graph = {
+        "skills/a.md": [Edge(target="skills/b.md", relationship="escalates_to", rationale="r")],
+        "skills/b.md": [],
+        "skills/c.md": [],  # c has no in-edges and no out-edges → orphan
+    }
+    stats = vsg.graph_stats(graph)
+    assert "skills/c.md" in stats["orphans"]
+    assert "skills/b.md" not in stats["orphans"]  # b has in-edge from a
+
+
+# ── run_checks integration ────────────────────────────────────────────────────────
+
+def test_run_checks_passes_all_valid(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    a = skills_dir / "a.md"
+    b = skills_dir / "b.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "a leads to b")])
+    _write_skill_with_edges(b, [("skills/a.md", "alternative_to", "b is alternative to a")])
+    cross_ref = tmp_path / "cross-reference-map.md"
+    cross_ref.write_text(
+        "## Skill Relationship Graph\n\n| `skills/a.md` |\n| `skills/b.md` |\n",
+        encoding="utf-8",
+    )
+    errors, warnings, stats = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert stats["nodes"] == 2
+    assert stats["edges"] == 2
+
+def test_run_checks_e1_missing_skills_dir(tmp_path):
+    errors, warnings, stats = vsg.run_checks(
+        skills_dir=tmp_path / "nonexistent",
+        cross_ref_map=tmp_path / "map.md",
+    )
+    assert any("not found" in e for e in errors)
+    assert stats == {}
+
+def test_run_checks_e2_broken_path(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "a.md"
+    _write_skill_with_edges(skill, [("skills/missing.md", "escalates_to", "does not exist")])
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("not found" in e for e in errors)
+
+def test_run_checks_e3_invalid_type(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    b = skills_dir / "b.md"
+    _write_skill_no_section(b)
+    a = skills_dir / "a.md"
+    a.write_text(
+        "## Related skills / مهارات مرتبطة\n\n"
+        "* [b.md](../skills/b.md)\n"
+        "  — relationship: invented_type\n"
+        "  — some rationale\n",
+        encoding="utf-8",
+    )
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("unknown relationship type" in e for e in errors)
+
+def test_run_checks_e4_malformed_entry(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _write_skill_malformed_item(skills_dir / "a.md")
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("malformed entry" in e for e in errors)
+
+def test_run_checks_e5_self_reference(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "a.md"
+    _write_skill_with_edges(skill, [("skills/a.md", "depends_on", "itself")])
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, _, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("self-reference" in e for e in errors)
+
+def test_run_checks_w1_no_section(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    _write_skill_no_section(skills_dir / "a.md")
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Skill Relationship Graph\n| `skills/a.md` |\n", encoding="utf-8")
+    errors, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert any("no '## Related skills' section" in w for w in warnings)
+
+def test_run_checks_w2_orphan(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    a, b, c = skills_dir / "a.md", skills_dir / "b.md", skills_dir / "c.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "a leads to b")])
+    _write_skill_with_edges(b, [("skills/a.md", "alternative_to", "b to a")])
+    # c has a section but no valid entries → orphan
+    c.write_text(
+        "## Related skills / مهارات مرتبطة\n\n(no entries yet)\n",
+        encoding="utf-8",
+    )
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text(
+        "## Skill Relationship Graph\n"
+        "| `skills/a.md` |\n| `skills/b.md` |\n| `skills/c.md` |\n",
+        encoding="utf-8",
+    )
+    errors, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert errors == []
+    assert any("orphan" in w for w in warnings)
+
+def test_run_checks_w4_map_drift(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    b = skills_dir / "b.md"
+    _write_skill_no_section(b)
+    a = skills_dir / "a.md"
+    _write_skill_with_edges(a, [("skills/b.md", "escalates_to", "rationale")])
+    # cross_ref map exists but has no Skill Relationship Graph section
+    cross_ref = tmp_path / "map.md"
+    cross_ref.write_text("## Some Other Section\n", encoding="utf-8")
+    _, warnings, _ = vsg.run_checks(skills_dir=skills_dir, cross_ref_map=cross_ref)
+    assert any("Skill Relationship Graph" in w for w in warnings)

--- a/tests/test_validate_skill_graph.py
+++ b/tests/test_validate_skill_graph.py
@@ -1,0 +1,197 @@
+"""Tests for scripts/validate_skill_graph.py — Saudi Legal AI Framework"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import validate_skill_graph as vsg
+from validate_skill_graph import Edge
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _write_skill_with_edges(path: Path, edges: list) -> None:
+    items = []
+    for target, rel_type, rationale in edges:
+        items.append(
+            f"* [{target}](../{target})\n"
+            f"  — relationship: {rel_type}\n"
+            f"  — {rationale}"
+        )
+    body = "\n\n".join(items)
+    path.write_text(
+        "## Introduction\nIntro.\n\n"
+        "## Related skills / مهارات مرتبطة\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_no_section(path: Path) -> None:
+    path.write_text(
+        "## Introduction\nIntro.\n\n## 11. Relevant Regulations\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skill_malformed_item(path: Path) -> None:
+    path.write_text(
+        "## Related skills / مهارات مرتبطة\n\n"
+        "* some description without a link\n",
+        encoding="utf-8",
+    )
+
+
+# ── Heading detection ─────────────────────────────────────────────────────────
+
+def test_normalize_heading_strips_hashes():
+    assert vsg._normalize_heading("## Related skills") == "related skills"
+
+def test_normalize_heading_arabic():
+    assert vsg._normalize_heading("## مهارات مرتبطة") == "مهارات مرتبطة"
+
+def test_normalize_heading_strips_section_number():
+    assert vsg._normalize_heading("## 15. Related skills") == "related skills"
+
+def test_is_related_skills_heading_bilingual():
+    assert vsg._is_related_skills_heading("## Related skills / مهارات مرتبطة")
+
+def test_is_related_skills_heading_arabic_only():
+    assert vsg._is_related_skills_heading("## مهارات مرتبطة")
+
+def test_is_related_skills_heading_case_insensitive():
+    assert vsg._is_related_skills_heading("## RELATED SKILLS")
+
+def test_is_related_skills_heading_unrelated():
+    assert not vsg._is_related_skills_heading("## Related examples")
+
+def test_is_related_skills_heading_unrelated_arabic():
+    assert not vsg._is_related_skills_heading("## الأنظمة ذات الصلة")
+
+
+# ── Edge extraction ──────────────────────────────────────────────────────────
+
+VALID_EDGE_SECTION = (
+    "* [commercial-dispute.md](../skills/commercial-dispute.md)\n"
+    "  — relationship: escalates_to\n"
+    "  — a contract dispute may require Commercial Court proceedings\n"
+)
+
+def test_extract_skill_edges_single_valid_edge():
+    edges = vsg._extract_skill_edges(VALID_EDGE_SECTION)
+    assert len(edges) == 1
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert edges[0].relationship == "escalates_to"
+    assert "contract dispute" in edges[0].rationale
+
+def test_extract_skill_edges_multiple_edges():
+    section = (
+        "* [commercial-dispute.md](../skills/commercial-dispute.md)\n"
+        "  — relationship: escalates_to\n"
+        "  — breach may lead to litigation\n"
+        "\n"
+        "* [arbitration.md](../skills/arbitration.md)\n"
+        "  — relationship: escalates_to\n"
+        "  — arbitration clause may activate this path\n"
+    )
+    edges = vsg._extract_skill_edges(section)
+    assert len(edges) == 2
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert edges[1].target == "skills/arbitration.md"
+
+def test_extract_skill_edges_normalizes_dotdot_prefix():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: depends_on\n"
+        "  — rationale\n"
+    )
+    edges = vsg._extract_skill_edges(section)
+    assert edges[0].target == "skills/foo.md"
+
+def test_extract_skill_edges_no_links_returns_empty():
+    assert vsg._extract_skill_edges("no links here\n* plain bullet\n") == []
+
+def test_extract_skill_edges_missing_relationship_line_skips_entry():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  just some text without relationship:\n"
+        "  — rationale\n"
+    )
+    assert vsg._extract_skill_edges(section) == []
+
+def test_extract_skill_edges_invalid_relationship_token_rejected():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: escalates_to.\n"
+        "  — some rationale\n"
+    )
+    assert vsg._extract_skill_edges(section) == []
+
+
+# ── Malformed entry detection ─────────────────────────────────────────────────
+
+def test_find_malformed_entries_clean_returns_empty():
+    assert vsg._find_malformed_entries(VALID_EDGE_SECTION) == []
+
+def test_find_malformed_entries_no_link():
+    section = "* some text without a skills link\n"
+    result = vsg._find_malformed_entries(section)
+    assert len(result) == 1
+    assert "some text" in result[0]
+
+def test_find_malformed_entries_missing_relationship_line():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — just rationale without relationship line\n"
+    )
+    assert len(vsg._find_malformed_entries(section)) == 1
+
+def test_find_malformed_entries_missing_rationale_line():
+    section = (
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: escalates_to\n"
+    )
+    assert len(vsg._find_malformed_entries(section)) == 1
+
+
+# ── parse_skill ──────────────────────────────────────────────────────────────
+
+def test_parse_skill_with_valid_section(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_with_edges(f, [
+        ("skills/commercial-dispute.md", "escalates_to", "breach may lead to litigation"),
+    ])
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert has_section
+    assert len(edges) == 1
+    assert edges[0].target == "skills/commercial-dispute.md"
+    assert malformed == []
+
+def test_parse_skill_no_section(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_no_section(f)
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert not has_section
+    assert edges == []
+    assert malformed == []
+
+def test_parse_skill_malformed_entry(tmp_path):
+    f = tmp_path / "myskill.md"
+    _write_skill_malformed_item(f)
+    has_section, edges, malformed = vsg.parse_skill(f)
+    assert has_section
+    assert edges == []
+    assert len(malformed) == 1
+
+def test_parse_skill_arabic_heading(tmp_path):
+    f = tmp_path / "myskill.md"
+    f.write_text(
+        "## مهارات مرتبطة\n\n"
+        "* [foo.md](../skills/foo.md)\n"
+        "  — relationship: depends_on\n"
+        "  — rationale text\n",
+        encoding="utf-8",
+    )
+    has_section, edges, _ = vsg.parse_skill(f)
+    assert has_section
+    assert len(edges) == 1


### PR DESCRIPTION
## Summary

- Adds `scripts/validate_skill_graph.py` — a typed, bidirectional skill graph validator with 8 allowed relationship types, edge parsing, orphan/self-ref/malformed-entry detection, and graph statistics (nodes, edges, components, most-connected)
- Adds `## Related skills / مهارات مرتبطة` sections to all 7 `skills/*.md` files forming a 14-edge single-component graph (7 nodes, 1 connected component)
- Updates `docs/cross-reference-map.md` with a `## Skill Relationship Graph` table showing degree, relationship types, and connectivity per skill
- Wires `validate_skill_graph.py` into CI after `validate_example_coverage.py`

## Test Plan

- [x] 33 unit + integration tests in `tests/test_validate_skill_graph.py` (all passing)
- [x] Full suite: 151 tests pass (`pytest tests/`)
- [x] `python3 scripts/validate_skill_graph.py` exits 0 with 7 nodes, 14 edges, 1 component, no errors
- [x] All three validators pass in sequence: `validate_cross_refs.py` → `validate_example_coverage.py` → `validate_skill_graph.py`
- [x] W3 asymmetric warnings (8 one-directional edges) are informational and non-blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)