### PR TITLE
feat: add competition law source reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Open-source collection of legal skills, source references, and datasets that giv
 | الأداة | الوظيفة |
 |--------|---------|
 | `analyze_contract_clause` | تحليل بند عقدي وإرجاع JSON بمستوى الخطر والمواد القانونية |
-| `get_regulation_summary` | ملخص منظم لأي نظام سعودي من 18 مصدرا |
+| `get_regulation_summary` | ملخص منظم لأي نظام سعودي من 19 مصدرا |
 | `search_contract_risks` | البحث في قاعدة بيانات مخاطر العقود (30 بندا) |
 
 راجع [mcp-server/README.md](mcp-server/README.md) للتفاصيل الكاملة.
@@ -85,7 +85,7 @@ python3 -m pytest tests/test_eval_validator.py -q
 | المجلد | المحتوى | العدد |
 |--------|---------|-------|
 | `skills/` | ملفات مهارة قانونية موجهة للذكاء الاصطناعي | 9 |
-| `sources/` | ملخصات مرجعية للأنظمة السعودية الرسمية | 18 |
+| `sources/` | ملخصات مرجعية للأنظمة السعودية الرسمية | 19 |
 | `datasets/` | مجموعات بيانات قانونية منظمة وملفات مخاطر | 11 |
 | `examples/` | أمثلة تطبيقية موثقة عبر المجالات القانونية | 14 |
 | `prompts/` | قوالب مطالبات جاهزة للاستخدام | 3 |
@@ -121,6 +121,7 @@ saudi-legal-ai-framework/
 │   ├── evidence-law.md
 │   ├── e-commerce-law.md
 │   ├── zatca-e-invoicing.md
+│   ├── competition-law.md
 │   ├── civil-transactions-law.md
 │   ├── whistleblower-protection.md
 │   ├── legal-profession-law.md

--- a/docs/cross-reference-map.md
+++ b/docs/cross-reference-map.md
@@ -65,6 +65,7 @@ This map shows the relationships between project files. The goal: every contribu
 | `sources/commercial-courts.md` | `skills/compliance-check.md` | §11 | فض النزاعات التنظيمية |
 | `sources/commercial-courts.md` | `skills/arbitration.md` | §11 | الرقابة القضائية على التحكيم وتنفيذ الاحكام |
 | `sources/zatca-e-invoicing.md` | `skills/compliance-check.md` | §11 | الفوترة الإلكترونية — الإصدار والربط والتكامل |
+| `sources/competition-law.md` | `skills/commercial-dispute.md` | §11 | الممارسات المخلّة بالمنافسة وإساءة الوضع المهيمن والتركز الاقتصادي |
 
 ---
 

--- a/skills/commercial-dispute.md
+++ b/skills/commercial-dispute.md
@@ -371,6 +371,7 @@ What AI cannot assess in this context:
 | نظام الإفلاس | م/50 لعام 1439هـ | إعادة الهيكلة والتصفية | `sources/bankruptcy-law.md` | [boe.gov.sa](https://laws.boe.gov.sa/BoeLaws/Laws/LawDetails/68204119-84f1-4789-8fad-a9ec014c3788/1) |
 | نظام الأوراق التجارية | م/37 لعام 1383هـ | الشيكات والكمبيالات والسندات | — | [boe.gov.sa](https://laws.boe.gov.sa/BoeLaws/Laws/LawDetails/4763eb94-047b-46f1-9697-a9a700f1b7ed/1) |
 | نظام الوكالة التجارية | م/11 لعام 1382هـ | نزاعات الوكلاء التجاريين | — | <!-- TO VERIFY: تحقق من رابط boe.gov.sa --> |
+| نظام المنافسة | م/75 لعام 1440هـ | الممارسات المخلّة بالمنافسة وإساءة الوضع المهيمن والتركز الاقتصادي | `sources/competition-law.md` | [gac.gov.sa](https://gac.gov.sa) <!-- TO VERIFY: رابط النص على boe.gov.sa --> |
 **صيغ الاستشهاد:** راجع `sources/regulation-index.md` للصيغ الرسمية المعتمدة.
 
 **المصادر الرسمية:** هيئة الخبراء بمجلس الوزراء (boe.gov.sa) — الجريدة الرسمية (أم القرى) (uqn.gov.sa) — منصة ناجز القضائية (najiz.sa) — الهيئة السعودية للتحكيم التجاري (scca.org.sa)

--- a/sources/competition-law.md
+++ b/sources/competition-law.md
@@ -1,0 +1,161 @@
+# المصدر: نظام المنافسة
+# Source: Competition Law
+
+**المرجع الرسمي:** نظام المنافسة الصادر بالمرسوم الملكي رقم م/75 لعام 1440هـ
+**Official Reference:** Competition Law issued by Royal Decree No. M/75 of 1440H
+
+**نوع الأداة:** نظام صادر بمرسوم ملكي — **مصدر نظامي وليس منصة إجرائية**
+**Instrument Type:** Statute issued by Royal Decree — a legislative source, not a service platform
+
+**الجهة المختصة:** الهيئة العامة للمنافسة (GAC)
+**Competent Authority:** General Authority for Competition (GAC)
+
+---
+
+## ⚠️ تحذير / Warning
+
+> هذا ملخص تعليمي. اللائحة التنفيذية لنظام المنافسة والإرشادات والأدلة وعتبات التركز الاقتصادي تصدر وتُحدَّث عن طريق الهيئة العامة للمنافسة، ويجب التحقق من آخر اللوائح والإرشادات على gac.gov.sa قبل أي اعتماد.
+>
+> This is an educational summary. The Competition Law's Implementing Regulations, guidelines, and economic-concentration thresholds are issued and updated by the General Authority for Competition. Always verify the latest regulations and guidance on gac.gov.sa before relying on it.
+
+---
+
+## النطاق والتطبيق / Scope and Application
+
+- يسري على **جميع المنشآت** العاملة في السوق السعودية وعلى أي ممارسات تقع خارج المملكة ويكون لها أثر على المنافسة داخلها.
+- تُستثنى بعض الجهات وفق ما يحدده النظام ولائحته (مثل ما تملكه الدولة بالكامل في حالات معينة) — يحتاج تحقق من النص واللائحة.
+
+Applies to **all establishments** active in the Saudi market, and to conduct occurring outside the Kingdom that affects competition within it. Certain entities may be exempt as specified by the Law and its Regulations (e.g. wholly state-owned entities in defined cases) — verification required.
+
+---
+
+## المحاور الرئيسية / Core Pillars
+
+### 1. الاتفاقات والممارسات المخلّة بالمنافسة / Anti-Competitive Agreements & Practices
+
+تُحظر الاتفاقات والممارسات بين المنشآت المتنافسة التي يكون موضوعها أو أثرها الإخلال بالمنافسة، ومنها:
+- تحديد الأسعار أو شروط البيع/الشراء (اتفاق الأسعار)
+- اقتسام الأسواق أو العملاء أو مصادر التوريد
+- التلاعب في العطاءات والمناقصات
+- تقييد الكميات أو الإنتاج
+
+Agreements and practices among competitors whose object or effect is to restrict competition are prohibited — including price fixing, market/customer/supply allocation, bid rigging, and output restriction.
+
+### 2. إساءة استغلال الوضع المهيمن / Abuse of Dominant Position
+
+يُحظر على المنشأة ذات **الوضع المهيمن** في السوق إساءة استغلاله، مثل:
+- فرض أسعار بيع أو شراء غير عادلة
+- التمييز بين المتعاملين في شروط متماثلة
+- رفض التعامل دون مبرر بهدف إخراج منافس
+- البيع بأقل من التكلفة لإخراج المنافسين (الأسعار الافتراسية)
+
+> **الوضع المهيمن** لا يُحظر بذاته؛ المحظور هو **إساءة استغلاله**.
+
+A dominant establishment may not abuse its position (unfair pricing, discrimination, refusal to deal to exclude rivals, predatory pricing). Dominance itself is not prohibited — only its abuse.
+
+### 3. التركز الاقتصادي / Economic Concentration
+
+عمليات التركز الاقتصادي (الاندماج، الاستحواذ، الدمج، أو امتلاك أصول/حقوق تنقل السيطرة) التي تتجاوز **العتبات** المحددة تتطلب **إشعار/موافقة مسبقة** من الهيئة قبل الإتمام.
+
+- **العتبات (حدود الإيرادات/الحصص) تتغيّر** وتُحدَّد عبر لوائح وإرشادات الهيئة — يجب التحقق من آخر نسخة.
+- الإتمام قبل الحصول على عدم الممانعة قد يُعرّض الأطراف للمساءلة.
+
+Economic-concentration transactions (mergers, acquisitions, transfers of control) exceeding defined **thresholds** require prior notification/approval from the Authority before closing. Thresholds change and are set via GAC regulations/guidance — verify the latest. Closing before clearance may expose the parties to liability.
+
+### 4. دور الهيئة العامة للمنافسة / Role of the General Authority for Competition (GAC)
+
+- إصدار اللوائح والأدلة الإرشادية وعتبات التركز
+- تلقّي إشعارات التركز الاقتصادي والبتّ فيها
+- التحقيق في الممارسات المخلّة بالمنافسة وتوقيع الجزاءات
+- منح الاستثناءات وفق الضوابط النظامية
+
+GAC issues regulations/guidance and concentration thresholds, reviews concentration notifications, investigates anti-competitive conduct and imposes sanctions, and grants exemptions within the statutory framework.
+
+---
+
+## الأحكام الإلزامية / Mandatory Provisions
+
+> أحكام نظام المنافسة من النظام العام؛ لا يجوز للأطراف الاتفاق تعاقدياً على ما يخالفها أو على إعفاء أنفسهم منها.
+>
+> Competition Law provisions are of public order; parties cannot contract around them or exempt themselves by agreement.
+
+### 1. حظر الاتفاقات والممارسات المخلّة بالمنافسة / Prohibition of Anti-Competitive Conduct
+
+| الحقل | القيمة |
+|-------|-------|
+| **الوصف** | تُحظر الاتفاقات/الممارسات التي موضوعها أو أثرها الإخلال بالمنافسة (اتفاق الأسعار، اقتسام الأسواق، التلاعب بالعطاءات) |
+| **Description** | Agreements/practices whose object or effect restricts competition are prohibited |
+| **سبب الإلزام** | حكم آمر من النظام العام بموجب نظام المنافسة م/75 1440هـ |
+| **المرسوم الملكي** | م/75 لعام 1440هـ |
+| **الجهة النظامية** | الهيئة العامة للمنافسة (GAC) |
+| **الرابط الرسمي** | https://gac.gov.sa |
+| **حالة التحقق** | to_verify — المبادئ موثقة في الملخص؛ أرقام المواد والاستثناءات تحتاج تحقق من النص واللائحة |
+
+```
+verification_metadata:
+  verification_status: to_verify
+  source_type: official_regulation_summary
+  official_reference: Competition Law (Royal Decree M/75 1440H)
+  last_verified: 2026-06-19
+  review_priority: high
+```
+
+### 2. إخطار/موافقة التركز الاقتصادي قبل الإتمام / Pre-Closing Economic-Concentration Clearance
+
+| الحقل | القيمة |
+|-------|-------|
+| **الوصف** | عمليات التركز الاقتصادي المتجاوزة للعتبات تستلزم إشعار/موافقة الهيئة قبل الإتمام |
+| **Description** | Economic concentrations above thresholds require notification/approval before closing |
+| **سبب الإلزام** | التزام نظامي لحماية المنافسة في السوق |
+| **المرسوم الملكي** | م/75 لعام 1440هـ + اللائحة التنفيذية والعتبات الصادرة عن الهيئة |
+| **الجهة النظامية** | الهيئة العامة للمنافسة (GAC) |
+| **الرابط الرسمي** | https://gac.gov.sa |
+| **حالة التحقق** | to_verify — العتبات الحالية تحتاج تحقق من آخر لوائح/إرشادات الهيئة |
+
+```
+verification_metadata:
+  verification_status: to_verify
+  source_type: official_regulation_summary + authority_thresholds
+  official_reference: Competition Law (Royal Decree M/75 1440H) and GAC thresholds
+  last_verified: 2026-06-19
+  review_priority: high
+```
+
+**Practical Risk Note / ملاحظة عملية:**
+بنود عدم المنافسة وحصرية التوريد والتسعير في العقود التجارية قد تتقاطع مع نظام المنافسة. كما أن صفقات الاندماج والاستحواذ تستلزم فحص عتبات التركز الاقتصادي مبكراً — والاعتماد على عتبات قديمة خطأ شائع لأنها تتغيّر عبر إرشادات الهيئة.
+
+Non-compete, exclusive-supply, and pricing clauses in commercial contracts may intersect with the Competition Law. M&A deals require early review of concentration thresholds — relying on outdated thresholds is a common error, as they change via GAC guidance.
+
+---
+
+## المصادر الرسمية / Official Sources
+
+- **الهيئة العامة للمنافسة (GAC):** [gac.gov.sa](https://gac.gov.sa)
+- **هيئة الخبراء بمجلس الوزراء:** [boe.gov.sa](https://boe.gov.sa)
+- **الجريدة الرسمية (أم القرى):** [uqn.gov.sa](https://uqn.gov.sa)
+
+---
+
+## Human Legal Review Required / يجب مراجعة قانونية بشرية
+
+| الموضوع | الإشكالية | أولوية المراجعة |
+|---------|----------|----------------|
+| عتبات التركز الاقتصادي الحالية | تتغيّر عبر لوائح/إرشادات الهيئة — تحتاج تحقق من آخر نسخة على gac.gov.sa | عالية |
+| أرقام مواد النظام | الملخص يصف المبادئ دون أرقام المواد — تحتاج تحقق من النص الرسمي | عالية |
+| الاستثناءات وحالات عدم السريان | نطاق الإعفاءات (وما تملكه الدولة) يحتاج تحقق من النظام واللائحة | متوسطة |
+| العقوبات والغرامات | جدول الجزاءات يحتاج تحقق من النص المحدَّث | متوسطة |
+| رابط boe.gov.sa الرسمي للمرسوم م/75 | يحتاج تحقق من الرابط الدقيق للنص على boe.gov.sa | متوسطة |
+
+<!-- TODO: يحتاج تحقق — أرقام مواد نظام المنافسة م/75 1440هـ وعتبات التركز الاقتصادي والعقوبات من المصدر الرسمي على gac.gov.sa و boe.gov.sa -->
+
+---
+
+## See also / انظر أيضًا
+
+المهارات التي تستند إلى هذا المصدر / Skills that cite this source:
+
+| Skill | Section | طبيعة الاستخدام |
+|-------|---------|----------------|
+| [skills/commercial-dispute.md](../skills/commercial-dispute.md) | §11 الأنظمة ذات الصلة | الممارسات المخلّة بالمنافسة وإساءة الوضع المهيمن والتركز الاقتصادي |
+
+> للاطلاع على الفهرس الكامل: [`docs/cross-reference-map.md`](../docs/cross-reference-map.md)

--- a/sources/regulation-index.md
+++ b/sources/regulation-index.md
@@ -226,6 +226,23 @@ When citing any regulation in any other project file, use the **Common Citation 
 
 ---
 
+### 14. نظام المنافسة (Competition Law)
+
+| الحقل | القيمة |
+|-------|-------|
+| **الاسم العربي** | نظام المنافسة |
+| **الاسم الإنجليزي** | Competition Law |
+| **النوع** | نظام صادر بمرسوم ملكي |
+| **رقم المرسوم الملكي** | م/75 |
+| **سنة الإصدار** | 1440هـ |
+| **الجهة المختصة** | الهيئة العامة للمنافسة (GAC) |
+| **صيغة الاستشهاد** | `Competition Law (Royal Decree M/75 1440H)` |
+| **المصدر الرسمي** | gac.gov.sa — boe.gov.sa |
+| **ملفات المشروع ذات الصلة** | `sources/competition-law.md` |
+| **ملاحظات** | يغطي الاتفاقات والممارسات المخلّة بالمنافسة، إساءة استغلال الوضع المهيمن، والتركز الاقتصادي. عتبات التركز والإرشادات تُحدِّثها الهيئة — يجب التحقق من آخر نسخة |
+
+---
+
 ## جدول مرجع سريع / Quick Reference Table
 
 | الاسم الإنجليزي | رقم المرسوم | السنة | صيغة الاستشهاد المختصرة |
@@ -243,6 +260,7 @@ When citing any regulation in any other project file, use the **Common Citation 
 | Whistleblower Protection Law | M/148 | 1445H | `Whistleblower Protection Law (Royal Decree M/148 1445H)` |
 | Saudi Legal Profession Law / SBA | [يحتاج تحقق] | — | `Saudi Legal Profession Law / Saudi Bar Association (SBA) — sba.gov.sa` |
 | ZATCA E-Invoicing Regulation | قرار (1-20) — لائحة تنظيمية | 1442H | `ZATCA E-Invoicing Regulation (Board Resolution 1-20, 1442H)` |
+| Competition Law | M/75 | 1440H | `Competition Law (Royal Decree M/75 1440H)` |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a dedicated Competition Law source reference
- Documents the Competition Law as a Royal Decree-based legal source
- Covers restrictive agreements, abuse of dominant position, economic concentration, and the role of the General Authority for Competition
- Updates regulation index, commercial dispute skill cross-reference, cross-reference map, and README source count

## Validation
- `python3 scripts/validate_cross_refs.py` passed
- `python3 -m pytest --tb=short -q` passed: 198 tests
- `python3 evals/validate_cases.py` passed
- `git diff --check` passed
- Secret scan passed

## Notes
- Competition eval cases and source registry were intentionally left for a later PR
- MCP source loading was intentionally left for a later PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)