### PR TITLE
docs: update pages homepage disclaimer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,6 +36,13 @@
 
   <main id="main-content">
 
+  <!-- ── Legal disclaimer ── -->
+  <div class="legal-disclaimer" role="note"
+       style="margin:1rem auto;max-width:960px;padding:0.75rem 1rem;border:1px solid #e0c98a;background:#fdf8ec;border-radius:8px;color:#5a4a1f;font-size:0.95rem;line-height:1.6;text-align:center;">
+    <span>⚠️ للبحث الأولي فقط — ليس استشارة قانونية.</span><br />
+    <span dir="ltr">For preliminary research only — not legal advice.</span>
+  </div>
+
   <!-- ── Hero ── -->
   <section class="hero">
     <span class="hero-eyebrow">منصة معرفية مفتوحة المصدر</span>
@@ -69,8 +76,9 @@
   <!-- ── Stats bar ── -->
   <section class="stats-bar" aria-label="إحصائيات المنصة">
     <div class="stat-item">
-      <span class="stat-number">17</span>
-      <span class="stat-label">مصدر تشريعي رسمي</span>
+      <span class="stat-number">20</span>
+      <span class="stat-label">ملفاً مرجعياً</span>
+      <span class="stat-label" style="font-size:0.75rem;opacity:0.75;">تشمل 17 ملخصاً نظامياً و3 ملفات فهرسة/بيانات</span>
     </div>
     <div class="stat-divider" aria-hidden="true"></div>
     <div class="stat-item">


### PR DESCRIPTION
## Summary
- Adds the bilingual "preliminary research only / not legal advice" disclaimer to the GitHub Pages homepage
- Updates the homepage source statistic from 17 legislative sources to 20 reference files
- Clarifies that the 20 files include 17 regulation summaries and 3 index/data files

## Validation
- `git diff --check` passed
- Secret scan passed
- Only `docs/index.html` changed

## Notes
- No changes to README, sources, skills, evals, or MCP files

🤖 Generated with [Claude Code](https://claude.com/claude-code)